### PR TITLE
feat: implement gitignore-based file sync matching Databricks CLI (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 A Jupyter kernel for complete remote execution on Databricks clusters.
 
-## Features
+## 1. Features
 
 - Execute Python code entirely on Databricks clusters
 - No local Python execution (unlike Databricks Connect)
 - Seamless integration with JupyterLab
 
-## Requirements
+## 2. Requirements
 
 - Python 3.11 or later
 - Databricks workspace with Personal Access Token
 - mise (for tool version management)
 
-## Quick Start
+## 3. Quick Start
 
 1. Install mise
 
@@ -29,16 +29,75 @@ A Jupyter kernel for complete remote execution on Databricks clusters.
    make sync
    ```
 
-3. Configure Databricks credentials
+3. Configure Databricks credentials (see Authentication section below)
 
-   ```bash
-   export DATABRICKS_HOST=https://your-workspace.cloud.databricks.com
-   export DATABRICKS_TOKEN=your-personal-access-token
-   ```
+## 4. Authentication
 
-## Development
+This kernel uses the [Databricks SDK for Python](https://docs.databricks.com/en/dev-tools/sdk-python.html) for authentication. The SDK automatically resolves credentials in the following order:
 
-### Available Commands
+1. Environment variables (`DATABRICKS_HOST`, `DATABRICKS_TOKEN`)
+2. Databricks CLI configuration (`~/.databrickscfg`)
+3. Azure CLI / Google Cloud authentication (if applicable)
+
+### 4.1. Required Permissions
+
+The authenticated user or service principal needs the following workspace permissions:
+
+- **Cluster access**: "Can Attach To" or "Can Restart" permission on the target cluster
+- **DBFS access**: Read/write access to `/tmp/` for file synchronization
+- **Workspace access**: Read/write access to `/Workspace/Users/{your-email}/` for code extraction
+
+Note: Databricks PATs inherit the permissions of the user who created them. For fine-grained access control, consider using [OAuth](https://docs.databricks.com/en/dev-tools/auth/oauth-m2m.html) or configure cluster access control lists.
+
+### 4.2. Environment Variables
+
+```bash
+export DATABRICKS_HOST=https://your-workspace.cloud.databricks.com
+export DATABRICKS_TOKEN=your-personal-access-token
+export DATABRICKS_CLUSTER_ID=your-cluster-id
+```
+
+### 4.3. Using Databricks CLI
+
+If you have the Databricks CLI configured, the SDK will use `~/.databrickscfg`:
+
+```bash
+databricks configure --token
+```
+
+### 4.4. Configuration File
+
+You can also set `cluster_id` in `.databricks-kernel.yaml`:
+
+```yaml
+cluster_id: "0123-456789-abcdef12"
+```
+
+For more authentication options including OAuth and SSO, see [Databricks SDK Authentication](https://docs.databricks.com/en/dev-tools/sdk-python.html#authentication).
+
+## 5. File Synchronization
+
+This kernel synchronizes local files to DBFS for execution on the remote cluster. The synchronization behavior matches the [Databricks CLI](https://docs.databricks.com/en/dev-tools/cli/index.html).
+
+### 5.1. Excluded Files
+
+- `.gitignore` patterns: All patterns in your `.gitignore` file are respected
+- `.databricks` directory: Always excluded (matching Databricks CLI behavior)
+
+### 5.2. Custom Exclusions
+
+You can add additional exclusion patterns in `.databricks-kernel.yaml`:
+
+```yaml
+sync:
+  exclude:
+    - "*.log"
+    - "data/"
+```
+
+## 6. Development
+
+### 6.1. Available Commands
 
 | Command | Description |
 |---------|-------------|
@@ -47,13 +106,13 @@ A Jupyter kernel for complete remote execution on Databricks clusters.
 | `make test` | Run tests |
 | `make jupyter` | Start JupyterLab |
 
-### Code Quality
+### 6.2. Code Quality
 
 ```bash
 mise exec -- pre-commit run --all-files
 ```
 
-## Databricks Runtime Compatibility
+## 7. Databricks Runtime Compatibility
 
 | Runtime | Python | Status |
 |---------|--------|--------|
@@ -61,6 +120,6 @@ mise exec -- pre-commit run --all-files
 | 16.4 LTS | 3.12.3 | Recommended |
 | 15.4 LTS | 3.11.11 | Supported |
 
-## License
+## 8. License
 
 Apache License 2.0

--- a/src/jupyter_databricks_kernel/config.py
+++ b/src/jupyter_databricks_kernel/config.py
@@ -12,19 +12,16 @@ import yaml
 
 @dataclass
 class SyncConfig:
-    """Configuration for file synchronization."""
+    """Configuration for file synchronization.
+
+    The sync module applies default exclusion patterns automatically,
+    including .gitignore rules. User-specified exclude patterns here
+    are applied in addition to those defaults.
+    """
 
     enabled: bool = True
     source: str = "."
-    exclude: list[str] = field(
-        default_factory=lambda: [
-            ".git",
-            "__pycache__",
-            ".venv",
-            "*.pyc",
-            ".pytest_cache",
-        ]
-    )
+    exclude: list[str] = field(default_factory=list)
     max_size_mb: float | None = None
     max_file_size_mb: float | None = None
 
@@ -92,6 +89,10 @@ class Config:
     def validate(self) -> list[str]:
         """Validate the configuration.
 
+        Note: Authentication is handled by the Databricks SDK, which
+        automatically resolves credentials from environment variables,
+        CLI config, or cloud provider authentication.
+
         Returns:
             List of validation error messages. Empty if valid.
         """
@@ -101,19 +102,6 @@ class Config:
             errors.append(
                 "DATABRICKS_CLUSTER_ID environment variable is not set. "
                 "Please set it to your Databricks cluster ID."
-            )
-
-        # Check for DATABRICKS_HOST and DATABRICKS_TOKEN
-        if not os.environ.get("DATABRICKS_HOST"):
-            errors.append(
-                "DATABRICKS_HOST environment variable is not set. "
-                "Please set it to your Databricks workspace URL."
-            )
-
-        if not os.environ.get("DATABRICKS_TOKEN"):
-            errors.append(
-                "DATABRICKS_TOKEN environment variable is not set. "
-                "Please set it to your Databricks personal access token."
             )
 
         return errors


### PR DESCRIPTION
## Summary

Implements secure credential management and file synchronization for Issue #6.

### Changes

- **`.gitignore` support**: File sync now respects `.gitignore` patterns using the `pathspec` library, matching [Databricks CLI behavior](https://github.com/databricks/cli/blob/main/libs/git/view.go)
- **Simplified auth validation**: Removed redundant `DATABRICKS_HOST`/`DATABRICKS_TOKEN` checks; authentication is fully delegated to Databricks SDK
- **Documentation**: Added Authentication and File Synchronization sections to README

## Design Decisions

### Why match Databricks CLI instead of hardcoding security patterns?

Initial implementation included hardcoded exclusions for `.env`, `*.pem`, `*.key`, etc. After discussion, we aligned with Databricks CLI's approach:

| Approach | Databricks CLI | This PR |
|----------|----------------|---------|
| Hardcoded exclusions | `.databricks` only | `.databricks` only |
| Other exclusions | User's `.gitignore` | User's `.gitignore` |

**Rationale:**
- Consistency with existing Databricks tooling
- Users already manage sensitive files via `.gitignore`
- Avoids false sense of security from incomplete hardcoded lists
- Simpler, more predictable behavior

### Why delegate authentication to SDK?

The Databricks SDK for Python handles authentication automatically:
1. Environment variables (`DATABRICKS_HOST`, `DATABRICKS_TOKEN`)
2. Databricks CLI config (`~/.databrickscfg`)
3. Azure CLI / Google Cloud auth

No need for this kernel to validate or manage credentials separately.

## What's NOT Implemented (and Why)

| Feature | Reason |
|---------|--------|
| Token masking in logs | SDK handles auth internally; no tokens exposed in standard logging |
| `.env` file reading | SDK doesn't read `.env`; users should use environment variables or CLI config |
| Hardcoded `.env`/`*.pem` exclusions | Matches Databricks CLI; users manage via `.gitignore` |

## Test Plan

- [x] All 49 tests pass
- [x] pre-commit hooks pass (ruff, mypy, gitleaks)
- [x] `.gitignore` patterns correctly exclude files
- [x] `.databricks` directory always excluded
- [x] Files not in `.gitignore` are synced (matching CLI behavior)

## Documentation Added

- Required permissions (cluster, DBFS, workspace access)
- Environment variable configuration
- Databricks CLI configuration
- Configuration file (`.databricks-kernel.yaml`) for `cluster_id`
- File synchronization behavior and custom exclusions
- Links to OAuth/SSO documentation

Closes #6