### PR TITLE
docs: rename package name to jupyter-databricks-kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jupyter-databricks-session-kernel
+# jupyter-databricks-kernel
 
 A Jupyter kernel for complete remote execution on Databricks clusters.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation
 
-Welcome to the jupyter-databricks-session-kernel documentation.
+Welcome to the jupyter-databricks-kernel documentation.
 
 ## 1. Quick Links
 


### PR DESCRIPTION
## Summary

- Rename package name from `jupyter-databricks-session-kernel` to `jupyter-databricks-kernel` in documentation
- Align documentation with the actual repository name

## Changes

| File | Change |
|------|--------|
| README.md | Update title |
| docs/README.md | Update description |

## Test plan

- [x] Verify README.md title matches repository name
- [x] Verify docs/README.md description is consistent

Closes #14