### PR TITLE
docs: update README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ A Jupyter kernel for complete remote execution on Databricks clusters.
 1. Install the kernel:
 
    ```bash
+   # With uv
+   uv pip install jupyter-databricks-kernel
+   uv run python -m jupyter_databricks_kernel.install
+
+   # With pip
    pip install jupyter-databricks-kernel
    python -m jupyter_databricks_kernel.install
    ```
@@ -38,7 +43,7 @@ A Jupyter kernel for complete remote execution on Databricks clusters.
 3. Start JupyterLab and select "Databricks Session" kernel:
 
    ```bash
-   jupyter lab
+   jupyter-lab
    ```
 
 4. Run a simple test:


### PR DESCRIPTION
## Summary

- Add uv installation instructions alongside pip
- Change `jupyter lab` to `jupyter-lab` command

## Changes

- Add `uv pip install` + `uv run python -m` instructions for uv users
- Change `jupyter lab` to `jupyter-lab` in Quick Start section

## Test plan

- [ ] Verify README.md renders correctly on GitHub

Closes #65