### PR TITLE
build: use hatch-vcs for automatic version management

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install mise

--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,6 @@ __marimo__/
 
 # Databricks kernel cache
 .jupyter-databricks-kernel-cache.json
+
+# hatch-vcs generated version file
+src/jupyter_databricks_kernel/_version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "jupyter-databricks-kernel"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A Jupyter kernel for complete remote execution on Databricks clusters"
 readme = "README.md"
 license = "Apache-2.0"
@@ -24,6 +24,12 @@ dev = [
     "pytest>=7.0.0",
     "ruff>=0.14.0",
 ]
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/jupyter_databricks_kernel/_version.py"
 
 [tool.ruff]
 target-version = "py311"

--- a/src/jupyter_databricks_kernel/__init__.py
+++ b/src/jupyter_databricks_kernel/__init__.py
@@ -1,3 +1,5 @@
 """Jupyter kernel for Databricks remote execution."""
 
-__version__ = "0.1.0"
+from ._version import __version__
+
+__all__ = ["__version__"]

--- a/uv.lock
+++ b/uv.lock
@@ -757,7 +757,6 @@ wheels = [
 
 [[package]]
 name = "jupyter-databricks-kernel"
-version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "databricks-sdk" },


### PR DESCRIPTION
## Summary

- Add hatch-vcs for automatic version management from git tags
- Simplify release process: only tagging and pushing required

## Background

Previously, releasing required:
1. Update version in pyproject.toml
2. Commit
3. Create tag
4. Push

With hatch-vcs, version is derived from git tags automatically, ensuring single source of truth and eliminating version mismatches.

## Changes

- `pyproject.toml`: Add hatch-vcs to build-system requires, change version to dynamic
- `__init__.py`: Import `__version__` from generated `_version.py`
- `.gitignore`: Add `_version.py` (auto-generated file)
- `publish.yaml`: Add `fetch-depth: 0` for git tag access in CI

## Test plan

- [x] `uv sync`: Successfully generates `_version.py`
- [x] Version import works correctly
- [x] All 121 tests pass

Closes #70