### PR TITLE
chore: remove shellcheck from pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,12 +40,6 @@ repos:
         language: system
         files: ^\.github/workflows/.*\.(yml|yaml)$
 
-      - id: shellcheck
-        name: shellcheck
-        entry: mise exec -- shellcheck
-        language: system
-        types: [shell]
-
       - id: ruff-check
         name: ruff check
         entry: mise exec -- uv run --no-sync ruff check --fix

--- a/mise.toml
+++ b/mise.toml
@@ -4,7 +4,6 @@ uv = "0.9.16"
 
 # Development tools
 pre-commit = "4.5.0"
-shellcheck = "0.11.0"
 
 # Aqua Tools
 "aqua:gitleaks/gitleaks"      = "8.30.0"


### PR DESCRIPTION
## Summary

- Remove shellcheck from mise.toml and .pre-commit-config.yaml

## Background

- This is a Python project with no shell scripts in the source code
- shellcheck hook always shows "(no files to check) Skipped"
- Keeping unused tools adds unnecessary maintenance burden

## Changes

- mise.toml: Remove `shellcheck = "0.11.0"`
- .pre-commit-config.yaml: Remove shellcheck hook block

## Test plan

- [x] `pre-commit run --all-files` passes
- [x] shellcheck no longer appears in hook list

Fixes #72