### PR TITLE
build: add Python classifiers to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,17 @@ description = "A Jupyter kernel for complete remote execution on Databricks clus
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.11"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: Jupyter",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 dependencies = [
     "databricks-sdk>=0.30.0,<1.0.0",
     "ipykernel>=6.20.0",


### PR DESCRIPTION
## Summary

- Add classifiers to pyproject.toml for PyPI badge to display supported Python versions
- Add metadata classifiers (Development Status, Framework, License, etc.)

## Test plan

- [x] ruff check: All checks passed
- [x] uv build: Successfully built
- [x] Confirmed classifiers are included in wheel METADATA

Fixes #78