### PR TITLE
feat: show running indicator during command execution (#12)

### DIFF
--- a/src/jupyter_databricks_kernel/kernel.py
+++ b/src/jupyter_databricks_kernel/kernel.py
@@ -157,6 +157,18 @@ class DatabricksKernel(Kernel):
                     },
                 )
 
+    def _send_progress(self, message: str) -> None:
+        """Send a progress message to stderr.
+
+        Args:
+            message: The progress message to display.
+        """
+        self.send_response(
+            self.iopub_socket,
+            "stream",
+            {"name": "stderr", "text": f"{message}\n"},
+        )
+
     async def do_execute(
         self,
         code: Any,
@@ -207,7 +219,7 @@ class DatabricksKernel(Kernel):
         # Execute on Databricks
         assert self.executor is not None
         try:
-            result = self.executor.execute(code_str)
+            result = self.executor.execute(code_str, on_progress=self._send_progress)
 
             # Handle reconnection: re-run setup code and notify user
             if result.reconnected:


### PR DESCRIPTION
Add a rotating dots indicator (Running., Running.., Running...) that
displays while commands are executing on the Databricks cluster.

## Summary

Implement polling-based progress indicator to show users that the
kernel is actively working during command execution.

## Background

Previously, the kernel blocked silently during command execution,
leaving users unsure if the kernel was working or frozen. This change
provides visual feedback during execution.

## Changes

- Add `_execute_with_polling()` method for manual status polling
- Add `on_progress` callback parameter to `execute()` method
- Add `_send_progress()` method in kernel to display progress
- Add `POLL_INTERVAL_SECONDS` (1 second) constant
- Add `PROGRESS_DOTS` pattern for rotating indicator

## Technical Details

- Use `command_execution.execute()` without calling `result()` to get
  the Wait object, then access `waiter.command_id` via `__getattr__`
- Poll `command_status()` every 1 second until FINISHED/ERROR/CANCELLED
- Callback function decouples executor from kernel, maintaining
  separation of concerns
- Progress messages sent to stderr via Jupyter's iopub_socket

## Testing

- All 138 tests pass
- Added 4 new tests for polling in test_executor.py
- Added 2 new tests for progress notification in test_kernel.py

## Related URLs

- https://github.com/i9wa4/jupyter-databricks-kernel/issues/12
