### PR TITLE
fix: search parent directories for pyproject.toml

### DIFF
--- a/src/jupyter_databricks_kernel/sync.py
+++ b/src/jupyter_databricks_kernel/sync.py
@@ -427,13 +427,19 @@ class FileSync:
     def _get_source_path(self) -> Path:
         """Get the source directory path.
 
+        If pyproject.toml was found, resolves source relative to its location.
+        Otherwise, falls back to cwd for backward compatibility.
+
         Returns:
             Path to the source directory.
         """
         source = self.config.sync.source
         if source.startswith("./"):
             source = source[2:]
-        return Path.cwd() / source
+
+        # Use base_path (pyproject.toml location) if available, otherwise cwd
+        base = self.config.base_path if self.config.base_path else Path.cwd()
+        return base / source
 
     def _load_gitignore_spec(self, source_path: Path) -> pathspec.PathSpec:
         """Load and cache the combined PathSpec from default and configured patterns.


### PR DESCRIPTION
## Summary
- Add `base_path` field to Config to track pyproject.toml location
- Add `_find_pyproject_toml()` method to search parent directories (similar to ruff, pytest, git)
- Update `FileSync._get_source_path()` to resolve paths relative to base_path instead of cwd

## Test plan
- [x] Unit tests for `_find_pyproject_toml()` method
- [x] Unit tests for `base_path` field behavior
- [x] Unit tests for `_get_source_path()` with base_path
- [x] Manual verification with hierarchical project structure on Databricks cluster

Closes #102