### PR TITLE
feat: set cwd to sync directory for Git Folders compatibility

### DIFF
--- a/src/jupyter_databricks_kernel/sync.py
+++ b/src/jupyter_databricks_kernel/sync.py
@@ -798,6 +798,9 @@ os.remove(_local_zip)
 if _extract_dir not in sys.path:
     sys.path.insert(0, _extract_dir)
 
+# Set working directory for relative path compatibility (Git Folders/Jobs)
+os.chdir(_extract_dir)
+
 # Clean up variables
 del _extract_dir, _dbfs_zip_path, _local_zip
 """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,7 @@
 """Integration tests for jupyter-databricks-kernel.
 
 These tests require a real Databricks cluster and valid credentials.
-They are skipped in CI environments where DATABRICKS_CLUSTER_ID is not set.
+They are skipped in CI environments where cluster_id is not configured.
 
 Run with: pytest -m integration
 Skip with: pytest -m "not integration"
@@ -13,9 +13,23 @@ import os
 
 import pytest
 
+from jupyter_databricks_kernel.config import Config
+
+
+def _has_cluster_id() -> bool:
+    """Check if cluster_id is available from env or ~/.databrickscfg."""
+    if os.environ.get("DATABRICKS_CLUSTER_ID"):
+        return True
+    try:
+        config = Config.load()
+        return bool(config.cluster_id)
+    except Exception:
+        return False
+
+
 # Skip all tests in this module if no cluster is configured
-SKIP_INTEGRATION = not os.environ.get("DATABRICKS_CLUSTER_ID")
-SKIP_REASON = "DATABRICKS_CLUSTER_ID environment variable not set"
+SKIP_INTEGRATION = not _has_cluster_id()
+SKIP_REASON = "cluster_id not configured (env or ~/.databrickscfg)"
 
 
 @pytest.mark.integration

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -920,6 +920,26 @@ class TestSkipNonRegularFiles:
             shutil.rmtree(test_dir, ignore_errors=True)
 
 
+class TestGetSetupCode:
+    """Tests for get_setup_code method."""
+
+    def test_setup_code_includes_chdir(self, mock_config: MagicMock) -> None:
+        """Test that setup code sets working directory."""
+        file_sync = FileSync(mock_config, "test-session")
+        # Mock _get_user_name to avoid Databricks SDK authentication
+        file_sync._get_user_name = MagicMock(return_value="test@example.com")
+        setup_code = file_sync.get_setup_code("/tmp/test.zip")
+        assert "os.chdir(_extract_dir)" in setup_code
+
+    def test_setup_code_includes_sys_path(self, mock_config: MagicMock) -> None:
+        """Test that setup code adds to sys.path."""
+        file_sync = FileSync(mock_config, "test-session")
+        # Mock _get_user_name to avoid Databricks SDK authentication
+        file_sync._get_user_name = MagicMock(return_value="test@example.com")
+        setup_code = file_sync.get_setup_code("/tmp/test.zip")
+        assert "sys.path.insert(0, _extract_dir)" in setup_code
+
+
 class TestGetSourcePathWithBasePath:
     """Tests for _get_source_path with base_path."""
 


### PR DESCRIPTION
## Summary

- Add `os.chdir()` to set cwd to sync directory on Databricks cluster
- Fix integration test skip logic to check `~/.databrickscfg` for cluster_id

## Background

When executing notebooks via jupyter-databricks-kernel, the cwd was `/home/spark-...` instead of the sync directory. This caused relative path operations like `%pip install -r ../requirements.txt` to fail, even though they work in Git Folders and Databricks Jobs.

## Changes

- `sync.py`: Add `os.chdir(_extract_dir)` in `get_setup_code()` after sys.path modification
- `test_sync.py`: Add `TestGetSetupCode` class with tests for chdir and sys.path
- `test_integration.py`: Fix skip condition to also check `~/.databrickscfg` for cluster_id (follow-up to #93)

## Technical Details

- The `os.chdir()` is placed after `sys.path.insert()` and before the cleanup `del` statement
- This ensures cwd is set to `/Workspace/Users/{user}/jupyter_databricks_kernel/{session_id}`
- Session reconnection automatically restores cwd via the existing `_handle_reconnection()` mechanism

## Test Plan

- [x] All 183 tests pass (including 5 integration tests)
- [x] Manual test confirmed `os.getcwd() == sync_dir` on real cluster
- [x] Relative path operations (e.g., `os.listdir('src')`) work correctly

Closes #105