### PR TITLE
fix: use version tag instead of branch for gh-action-pypi-publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,4 +58,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # release/v1
+        uses: pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598 # v1.13.0


### PR DESCRIPTION
## Summary

- Change `pypa/gh-action-pypi-publish` from `release/v1` branch reference to `v1.13.0` tag reference
- Fix Renovate dependency lookup warning: "Could not determine new digest for update"

## Test plan

- [ ] Verify Renovate dashboard no longer shows the dependency lookup warning