### PR TITLE
docs: clarify authentication methods (#157)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ A Jupyter kernel for complete remote execution on Databricks clusters.
    export DATABRICKS_HOST=https://your-workspace.cloud.databricks.com
    export DATABRICKS_TOKEN=your-personal-access-token
 
+   # Service Principal authentication (alternative to PAT)
+   export DATABRICKS_CLIENT_ID=your-client-id
+   export DATABRICKS_CLIENT_SECRET=your-client-secret
+
    # Use specific profile from ~/.databrickscfg (optional)
    export DATABRICKS_CONFIG_PROFILE=your-profile-name
    ```


### PR DESCRIPTION
## Summary

Add Service Principal environment variable examples to the authentication block in README.

## Changes

- Added `DATABRICKS_CLIENT_ID` and `DATABRICKS_CLIENT_SECRET` env var examples to the OAuth M2M (Service Principal) authentication section in README.md

## Related

Closes #157