### PR TITLE
chore(ci): add Dependabot nix support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,3 +28,12 @@ updates:
           - "*"
     commit-message:
       prefix: "chore(deps)"
+
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
## Summary

Enable Dependabot to track Nix flake dependency updates.

## Changes

- Added `nix` ecosystem entry to `.github/dependabot.yml`

## Related

Part of ongoing dependency management improvements.