### PR TITLE
docs: MCP server usage pattern — execute_python tool, per-workspace deployment, mcp_profile routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,15 +219,64 @@ If the cluster is stopped, increase the startup timeout:
 papermill input.ipynb output.ipynb --kernel databricks --start_timeout 600 -p param1 value1
 ```
 
-## 7. Known Limitations
+## 7. MCP Server Integration
+
+`jupyter-databricks-kernel` can serve as the execution engine behind an
+MCP (Model Context Protocol) server, enabling AI agents to run Python on
+Databricks clusters without requiring direct workspace credentials on the
+client side.
+
+### 7.1. Architecture
+
+A companion MCP server (deployed as a Databricks App) is deployed once per
+Databricks workspace. It holds the workspace Service Principal credentials
+and exposes an `execute_python` tool via MCP. The kernel package's
+`DatabricksExecutor` class is imported by this server as its execution
+engine.
+
+Per-session isolation: `DatabricksExecutor` maintains a `context_id` per
+session. The HTTP adapter keeps a `session_store` keyed by `session_id`
+with a 30-minute idle TTL, giving each caller an isolated execution context.
+
+### 7.2. Per-Project Configuration
+
+Projects that use AI-driven execution create a config file at
+`.databricks/config.json` in the project root:
+
+```json
+{
+  "mcp_profile": "<profile-name>",
+  "cluster_id": "<cluster-id>"
+}
+```
+
+`mcp_profile` maps to a named entry in the AI agent's global config
+(`~/.claude.json` or equivalent). It is the sole workspace identity —
+`workspace_url` is intentionally omitted to avoid two sources of truth.
+
+Switching workspace means switching `mcp_profile` — no credential changes
+needed.
+
+### 7.3. AI Execution Flow
+
+1. AI agent reads `.databricks/config.json` to determine `mcp_profile` and
+   `cluster_id`
+2. AI agent calls `execute_python` on the MCP server identified by
+   `mcp_profile`
+3. The MCP server routes the request through `DatabricksExecutor`
+4. Result is returned to the AI agent
+5. AI agent writes output to `outputs/<filename>.output.md` (for `.py`
+   files) or updates the notebook in-place (for `.ipynb`)
+
+## 8. Known Limitations
 
 - Serverless compute is not supported (Command Execution API limitation)
 - `input()` and interactive prompts do not work
 - Interactive widgets (ipywidgets) are not supported
 
-## 8. Troubleshooting
+## 9. Troubleshooting
 
-### 8.1. Kernel feels slow
+### 9.1. Kernel feels slow
 
 File sync may be uploading unnecessary files. Check your sync settings:
 
@@ -264,10 +313,10 @@ File sync may be uploading unnecessary files. Check your sync settings:
    enabled = false
    ```
 
-## 9. Development
+## 10. Development
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for development setup and guidelines.
 
-## 10. License
+## 11. License
 
 Apache License 2.0

--- a/README.md
+++ b/README.md
@@ -279,9 +279,21 @@ session when isolated command contexts are required.
 ### 7.2. Project Routing
 
 If a companion server supports multiple workspaces, keep workspace routing in
-the companion server configuration. A project-local routing file such as
-`.databricks/config.json` can be used by that server, but it is external to this
-package's public API.
+the companion server configuration. This package can also read a project-local
+`.databricks/config.json` file as local routing metadata for `mcp_profile` and
+`cluster_id`.
+
+The `.databricks/` directory is also used by the Databricks CLI for local sync
+snapshots, bundle state, variable overrides, and generated artifacts. Keep this
+file limited to the top-level routing shape below, do not store companion-server
+state under CLI-managed subdirectories such as `.databricks/bundle/`, and do not
+rely on `.databricks/` for files that must be synchronized to the cluster. This
+package's file synchronization excludes `.databricks/` to match Databricks CLI
+behavior.
+
+Databricks CLI authentication remains in the normal Databricks configuration
+locations, such as `~/.databrickscfg` or the CLI token cache, not in this
+project routing file.
 
 Example external routing shape:
 

--- a/README.md
+++ b/README.md
@@ -307,15 +307,52 @@ Example external routing file at `.databricks/jupyter-databricks-kernel.json`:
 
 ```json
 {
-  "mcp_profile": "<profile-name>",
-  "cluster_id": "<cluster-id>"
+  "mcp_profile": "databricks-prod",
+  "cluster_id": "0123-456789-abcdef12"
 }
 ```
 
+Only two routing fields are read:
+
+| Field         | Effect |
+| ------------- | ------ |
+| `cluster_id`  | Sets `Config.cluster_id`; the Jupyter kernel, runner CLI, or companion server uses it as the target all-purpose cluster for `DatabricksExecutor`. |
+| `mcp_profile` | Sets `Config.mcp_profile`; the AI agent or companion adapter can use it to select the named MCP server/workspace profile. |
+
+Configuration precedence is field-by-field:
+
+1. Environment variables: `DATABRICKS_CLUSTER_ID` and
+   `DATABRICKS_MCP_PROFILE`
+2. `~/.databrickscfg` from the active Databricks profile
+3. `.databricks/jupyter-databricks-kernel.json`
+4. Legacy fallback: `.databricks/config.json`
+
+If the JSON above is present and no higher-priority value is set,
+`Config.load()` selects cluster `0123-456789-abcdef12` and profile
+`databricks-prod`. The runner commands and Jupyter kernel execute on that
+cluster, and an MCP-aware agent can call the companion server identified by
+`databricks-prod`.
+
+If the JSON is absent, the same fields fall back to environment variables and
+then `~/.databrickscfg`. If no source provides `cluster_id`, execution cannot
+choose a Databricks cluster until `cluster_id` is configured. If
+`DATABRICKS_CLUSTER_ID=dev-cluster` is set while the JSON contains
+`0123-456789-abcdef12`, the environment value wins and `dev-cluster` is used.
+
+This routing file does not configure authentication, store tokens, set
+`workspace_url`, create an MCP server, configure the Databricks CLI, configure
+Asset Bundles, or add files to cluster sync. Authentication remains in the
+normal Databricks SDK locations, such as environment variables,
+`~/.databrickscfg`, or the CLI token cache. Bundle state remains under
+CLI-managed paths such as `.databricks/bundle/`, and this package excludes
+`.databricks/` from synchronization.
+
 In this pattern, `mcp_profile` maps to a named companion server entry in the AI
-agent's global config. Avoid duplicating workspace identity in both
-`mcp_profile` and `workspace_url`; choose one source of truth in the companion
-server.
+agent's global config. This makes a project directory self-routing for the
+intended MCP/Jupyter workflow: switching projects can switch the companion MCP
+profile and cluster without changing local credentials or editing notebook code.
+Avoid duplicating workspace identity in both `mcp_profile` and `workspace_url`;
+choose one source of truth in the companion server.
 
 ### 7.3. Execution Flow
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Cluster ID is read from (in order of priority):
 
 1. `DATABRICKS_CLUSTER_ID` environment variable
 2. `~/.databrickscfg` (from active profile)
+3. `.databricks/jupyter-databricks-kernel.json` project routing config
+   (`.databricks/config.json` legacy fallback)
 
 Active profile is determined by `DATABRICKS_CONFIG_PROFILE` environment
 variable, or `DEFAULT` if not set.
@@ -280,22 +282,28 @@ session when isolated command contexts are required.
 
 If a companion server supports multiple workspaces, keep workspace routing in
 the companion server configuration. This package can also read a project-local
-`.databricks/config.json` file as local routing metadata for `mcp_profile` and
-`cluster_id`.
+`.databricks/jupyter-databricks-kernel.json` file as local routing metadata for
+`mcp_profile` and `cluster_id`.
 
 The `.databricks/` directory is also used by the Databricks CLI for local sync
 snapshots, bundle state, variable overrides, and generated artifacts. Keep this
-file limited to the top-level routing shape below, do not store companion-server
-state under CLI-managed subdirectories such as `.databricks/bundle/`, and do not
-rely on `.databricks/` for files that must be synchronized to the cluster. This
-package's file synchronization excludes `.databricks/` to match Databricks CLI
-behavior.
+package-owned file limited to the top-level routing shape below, do not store
+companion-server state under CLI-managed subdirectories such as
+`.databricks/bundle/`, and do not rely on `.databricks/` for files that must be
+synchronized to the cluster. This package's file synchronization excludes
+`.databricks/` to match Databricks CLI behavior.
+
+The older `.databricks/config.json` path is still read as a compatibility
+fallback for projects that adopted the initial runner configuration, but new
+projects should use `.databricks/jupyter-databricks-kernel.json`. The
+package-owned filename avoids treating generic `config.json` as this package's
+permanent claim inside the Databricks CLI local namespace.
 
 Databricks CLI authentication remains in the normal Databricks configuration
 locations, such as `~/.databrickscfg` or the CLI token cache, not in this
 project routing file.
 
-Example external routing shape:
+Example external routing file at `.databricks/jupyter-databricks-kernel.json`:
 
 ```json
 {
@@ -311,12 +319,15 @@ server.
 
 ### 7.3. Execution Flow
 
-1. The AI agent selects the companion MCP server for the target workspace.
-2. The companion server maps the request to a Databricks cluster.
-3. The companion server calls `DatabricksExecutor` from this package.
-4. `DatabricksExecutor` executes code through the Databricks Command Execution
+1. The AI agent reads project routing from
+   `.databricks/jupyter-databricks-kernel.json` or the legacy
+   `.databricks/config.json` fallback.
+2. The AI agent calls the companion MCP server identified by `mcp_profile`.
+3. The companion server maps the request to a Databricks cluster.
+4. The companion server calls `DatabricksExecutor` from this package.
+5. `DatabricksExecutor` executes code through the Databricks Command Execution
    API and returns the result.
-5. The companion server or AI agent decides whether and where to persist the
+6. The companion server or AI agent decides whether and where to persist the
    returned output.
 
 ## 8. Known Limitations

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ Cluster ID is read from (in order of priority):
 1. `DATABRICKS_CLUSTER_ID` environment variable
 2. `~/.databrickscfg` (from active profile)
 3. `.databricks/jupyter-databricks-kernel.json` project routing config
-   (`.databricks/config.json` legacy fallback)
 
 Active profile is determined by `DATABRICKS_CONFIG_PROFILE` environment
 variable, or `DEFAULT` if not set.
@@ -293,11 +292,9 @@ companion-server state under CLI-managed subdirectories such as
 synchronized to the cluster. This package's file synchronization excludes
 `.databricks/` to match Databricks CLI behavior.
 
-The older `.databricks/config.json` path is still read as a compatibility
-fallback for projects that adopted the initial runner configuration, but new
-projects should use `.databricks/jupyter-databricks-kernel.json`. The
-package-owned filename avoids treating generic `config.json` as this package's
-permanent claim inside the Databricks CLI local namespace.
+Generic `.databricks/config.json` is not read. The package-owned filename avoids
+treating generic `config.json` as this package's claim inside the Databricks CLI
+local namespace.
 
 Databricks CLI authentication remains in the normal Databricks configuration
 locations, such as `~/.databrickscfg` or the CLI token cache, not in this
@@ -325,7 +322,6 @@ Configuration precedence is field-by-field:
    `DATABRICKS_MCP_PROFILE`
 2. `~/.databrickscfg` from the active Databricks profile
 3. `.databricks/jupyter-databricks-kernel.json`
-4. Legacy fallback: `.databricks/config.json`
 
 If the JSON above is present and no higher-priority value is set,
 `Config.load()` selects cluster `0123-456789-abcdef12` and profile
@@ -357,8 +353,7 @@ choose one source of truth in the companion server.
 ### 7.3. Execution Flow
 
 1. The AI agent reads project routing from
-   `.databricks/jupyter-databricks-kernel.json` or the legacy
-   `.databricks/config.json` fallback.
+   `.databricks/jupyter-databricks-kernel.json`.
 2. The AI agent calls the companion MCP server identified by `mcp_profile`.
 3. The companion server maps the request to a Databricks cluster.
 4. The companion server calls `DatabricksExecutor` from this package.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ pip install papermill
 Run a notebook with parameter injection:
 
 ```bash
-papermill input.ipynb output.ipynb --kernel databricks -p param1 value1 -p param2 value2
+papermill input.ipynb output.ipynb --kernel databricks \
+  -p param1 value1 -p param2 value2
 ```
 
 Do NOT use the `--inplace` flag with papermill. Papermill is designed to
@@ -216,32 +217,40 @@ outputs; `--inplace` overwrites the source notebook and defeats this purpose.
 If the cluster is stopped, increase the startup timeout:
 
 ```bash
-papermill input.ipynb output.ipynb --kernel databricks --start_timeout 600 -p param1 value1
+papermill input.ipynb output.ipynb --kernel databricks \
+  --start_timeout 600 -p param1 value1
 ```
 
-## 7. MCP Server Integration
+## 7. MCP Server Usage Pattern
 
-`jupyter-databricks-kernel` can serve as the execution engine behind an
-MCP (Model Context Protocol) server, enabling AI agents to run Python on
-Databricks clusters without requiring direct workspace credentials on the
-client side.
+`jupyter-databricks-kernel` can be used by an external MCP (Model Context
+Protocol) server as its Databricks execution dependency. This repository does
+not ship an MCP server, Databricks App, HTTP adapter, or MCP tool definition.
 
-### 7.1. Architecture
+### 7.1. External Server Responsibilities
 
-A companion MCP server (deployed as a Databricks App) is deployed once per
-Databricks workspace. It holds the workspace Service Principal credentials
-and exposes an `execute_python` tool via MCP. The kernel package's
-`DatabricksExecutor` class is imported by this server as its execution
-engine.
+A companion MCP server can be deployed once per Databricks workspace. That
+server owns:
 
-Per-session isolation: `DatabricksExecutor` maintains a `context_id` per
-session. The HTTP adapter keeps a `session_store` keyed by `session_id`
-with a 30-minute idle TTL, giving each caller an isolated execution context.
+- Workspace authentication and Service Principal credentials
+- MCP transport and tool definitions
+- HTTP routing, if the server exposes an HTTP adapter
+- Session storage and timeout policy
+- Any output file persistence outside the command result returned by this
+  package
 
-### 7.2. Per-Project Configuration
+The server can import `DatabricksExecutor` from this package to run code on a
+configured all-purpose cluster. It should keep one executor per active client
+session when isolated command contexts are required.
 
-Projects that use AI-driven execution create a config file at
-`.databricks/config.json` in the project root:
+### 7.2. Project Routing
+
+If a companion server supports multiple workspaces, keep workspace routing in
+the companion server configuration. A project-local routing file such as
+`.databricks/config.json` can be used by that server, but it is external to this
+package's public API.
+
+Example external routing shape:
 
 ```json
 {
@@ -250,23 +259,20 @@ Projects that use AI-driven execution create a config file at
 }
 ```
 
-`mcp_profile` maps to a named entry in the AI agent's global config
-(`~/.claude.json` or equivalent). It is the sole workspace identity —
-`workspace_url` is intentionally omitted to avoid two sources of truth.
+In this pattern, `mcp_profile` maps to a named companion server entry in the AI
+agent's global config. Avoid duplicating workspace identity in both
+`mcp_profile` and `workspace_url`; choose one source of truth in the companion
+server.
 
-Switching workspace means switching `mcp_profile` — no credential changes
-needed.
+### 7.3. Execution Flow
 
-### 7.3. AI Execution Flow
-
-1. AI agent reads `.databricks/config.json` to determine `mcp_profile` and
-   `cluster_id`
-2. AI agent calls `execute_python` on the MCP server identified by
-   `mcp_profile`
-3. The MCP server routes the request through `DatabricksExecutor`
-4. Result is returned to the AI agent
-5. AI agent writes output to `outputs/<filename>.output.md` (for `.py`
-   files) or updates the notebook in-place (for `.ipynb`)
+1. The AI agent selects the companion MCP server for the target workspace.
+2. The companion server maps the request to a Databricks cluster.
+3. The companion server calls `DatabricksExecutor` from this package.
+4. `DatabricksExecutor` executes code through the Databricks Command Execution
+   API and returns the result.
+5. The companion server or AI agent decides whether and where to persist the
+   returned output.
 
 ## 8. Known Limitations
 

--- a/src/jupyter_databricks_kernel/config.py
+++ b/src/jupyter_databricks_kernel/config.py
@@ -13,8 +13,6 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 CANONICAL_PROJECT_CONFIG_PATH = Path(".databricks") / "jupyter-databricks-kernel.json"
-LEGACY_PROJECT_CONFIG_PATH = Path(".databricks") / "config.json"
-PROJECT_CONFIG_PATHS = (CANONICAL_PROJECT_CONFIG_PATH, LEGACY_PROJECT_CONFIG_PATH)
 
 
 @dataclass
@@ -72,19 +70,10 @@ class Config:
         """
         current = Path.cwd()
         for directory in [current] + list(current.parents):
-            for relative_path in PROJECT_CONFIG_PATHS:
-                candidate = directory / relative_path
-                if candidate.exists():
-                    if relative_path == LEGACY_PROJECT_CONFIG_PATH:
-                        logger.warning(
-                            "Found legacy project routing config at %s; use %s "
-                            "instead.",
-                            candidate,
-                            directory / CANONICAL_PROJECT_CONFIG_PATH,
-                        )
-                    else:
-                        logger.debug("Found project routing config at %s", candidate)
-                    return candidate
+            candidate = directory / CANONICAL_PROJECT_CONFIG_PATH
+            if candidate.exists():
+                logger.debug("Found project routing config at %s", candidate)
+                return candidate
         return None
 
     @classmethod
@@ -95,7 +84,6 @@ class Config:
         1. Environment variables (highest priority)
         2. ~/.databrickscfg (from active profile)
         3. .databricks/jupyter-databricks-kernel.json
-           (.databricks/config.json legacy fallback)
 
         Sync settings are loaded from pyproject.toml.
 

--- a/src/jupyter_databricks_kernel/config.py
+++ b/src/jupyter_databricks_kernel/config.py
@@ -12,6 +12,10 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+CANONICAL_PROJECT_CONFIG_PATH = Path(".databricks") / "jupyter-databricks-kernel.json"
+LEGACY_PROJECT_CONFIG_PATH = Path(".databricks") / "config.json"
+PROJECT_CONFIG_PATHS = (CANONICAL_PROJECT_CONFIG_PATH, LEGACY_PROJECT_CONFIG_PATH)
+
 
 @dataclass
 class SyncConfig:
@@ -60,18 +64,27 @@ class Config:
         return None
 
     @staticmethod
-    def _find_databricks_config_json() -> Path | None:
-        """Find .databricks/config.json in current or parent directories.
+    def _find_project_config_json() -> Path | None:
+        """Find project routing config JSON in current or parent directories.
 
         Returns:
-            Path to .databricks/config.json if found, None otherwise.
+            Path to project routing config JSON if found, None otherwise.
         """
         current = Path.cwd()
         for directory in [current] + list(current.parents):
-            candidate = directory / ".databricks" / "config.json"
-            if candidate.exists():
-                logger.debug("Found .databricks/config.json at %s", candidate)
-                return candidate
+            for relative_path in PROJECT_CONFIG_PATHS:
+                candidate = directory / relative_path
+                if candidate.exists():
+                    if relative_path == LEGACY_PROJECT_CONFIG_PATH:
+                        logger.warning(
+                            "Found legacy project routing config at %s; use %s "
+                            "instead.",
+                            candidate,
+                            directory / CANONICAL_PROJECT_CONFIG_PATH,
+                        )
+                    else:
+                        logger.debug("Found project routing config at %s", candidate)
+                    return candidate
         return None
 
     @classmethod
@@ -81,7 +94,8 @@ class Config:
         Priority order for cluster_id and mcp_profile:
         1. Environment variables (highest priority)
         2. ~/.databrickscfg (from active profile)
-        3. .databricks/config.json (project-local, lowest priority)
+        3. .databricks/jupyter-databricks-kernel.json
+           (.databricks/config.json legacy fallback)
 
         Sync settings are loaded from pyproject.toml.
 
@@ -108,11 +122,11 @@ class Config:
         if config.cluster_id is None or config.mcp_profile is None:
             config._load_from_databrickscfg()
 
-        # Load from .databricks/config.json if fields still not set
+        # Load from project-local routing config if fields still not set
         if config.cluster_id is None or config.mcp_profile is None:
-            databricks_config = cls._find_databricks_config_json()
-            if databricks_config is not None:
-                config._load_from_databricks_config_json(databricks_config)
+            project_config = cls._find_project_config_json()
+            if project_config is not None:
+                config._load_from_project_config_json(project_config)
 
         # Search for pyproject.toml if not explicitly provided
         if config_path is None:
@@ -176,11 +190,11 @@ class Config:
                 "MCP profile from databrickscfg [%s]: %s", profile, self.mcp_profile
             )
 
-    def _load_from_databricks_config_json(self, path: Path) -> None:
-        """Load cluster_id and mcp_profile from .databricks/config.json.
+    def _load_from_project_config_json(self, path: Path) -> None:
+        """Load cluster_id and mcp_profile from project routing config JSON.
 
         Args:
-            path: Path to .databricks/config.json.
+            path: Path to project routing config JSON.
 
         Raises:
             ValueError: If config contains workspace_url (intentionally absent

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -586,16 +586,16 @@ mcp_profile = cfg-profile
         assert config.mcp_profile == "env-profile"
 
 
-class TestDatabricksConfigJson:
-    """Tests for .databricks/config.json loader (M2)."""
+class TestDatabricksProjectConfigJson:
+    """Tests for project routing config JSON loader (M2)."""
 
-    def test_load_from_databricks_config_json(
+    def test_load_from_canonical_project_config_json(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test loading cluster_id and mcp_profile from .databricks/config.json."""
+        """Test loading from .databricks/jupyter-databricks-kernel.json."""
         config_dir = tmp_path / ".databricks"
         config_dir.mkdir()
-        (config_dir / "config.json").write_text(
+        (config_dir / "jupyter-databricks-kernel.json").write_text(
             '{"mcp_profile": "json-profile", "cluster_id": "json-cluster"}'
         )
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -607,13 +607,52 @@ class TestDatabricksConfigJson:
         assert config.cluster_id == "json-cluster"
         assert config.mcp_profile == "json-profile"
 
-    def test_workspace_url_raises_value_error(
+    def test_load_from_legacy_databricks_config_json(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test that workspace_url in config.json raises ValueError."""
+        """Test loading from legacy .databricks/config.json fallback."""
         config_dir = tmp_path / ".databricks"
         config_dir.mkdir()
         (config_dir / "config.json").write_text(
+            '{"mcp_profile": "legacy-profile", "cluster_id": "legacy-cluster"}'
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_MCP_PROFILE", raising=False)
+
+        config = Config.load()
+        assert config.cluster_id == "legacy-cluster"
+        assert config.mcp_profile == "legacy-profile"
+
+    def test_canonical_project_config_overrides_legacy_config_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test canonical project config is preferred over legacy config.json."""
+        config_dir = tmp_path / ".databricks"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            '{"mcp_profile": "legacy-profile", "cluster_id": "legacy-cluster"}'
+        )
+        (config_dir / "jupyter-databricks-kernel.json").write_text(
+            '{"mcp_profile": "canonical-profile", "cluster_id": "canonical-cluster"}'
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_MCP_PROFILE", raising=False)
+
+        config = Config.load()
+        assert config.cluster_id == "canonical-cluster"
+        assert config.mcp_profile == "canonical-profile"
+
+    def test_workspace_url_raises_value_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that workspace_url in project config raises ValueError."""
+        config_dir = tmp_path / ".databricks"
+        config_dir.mkdir()
+        (config_dir / "jupyter-databricks-kernel.json").write_text(
             '{"workspace_url": "https://example.databricks.com", "cluster_id": "x"}'
         )
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -627,10 +666,10 @@ class TestDatabricksConfigJson:
     def test_env_overrides_config_json(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test env var takes priority over .databricks/config.json."""
+        """Test env var takes priority over project config JSON."""
         config_dir = tmp_path / ".databricks"
         config_dir.mkdir()
-        (config_dir / "config.json").write_text(
+        (config_dir / "jupyter-databricks-kernel.json").write_text(
             '{"cluster_id": "json-cluster", "mcp_profile": "json-profile"}'
         )
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
@@ -645,10 +684,10 @@ class TestDatabricksConfigJson:
     def test_databrickscfg_overrides_config_json(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test ~/.databrickscfg takes priority over .databricks/config.json."""
+        """Test ~/.databrickscfg takes priority over project config JSON."""
         config_dir = tmp_path / ".databricks"
         config_dir.mkdir()
-        (config_dir / "config.json").write_text(
+        (config_dir / "jupyter-databricks-kernel.json").write_text(
             '{"cluster_id": "json-cluster", "mcp_profile": "json-profile"}'
         )
         databrickscfg = tmp_path / ".databrickscfg"
@@ -670,7 +709,7 @@ mcp_profile = cfg-profile
     def test_config_json_not_found_is_noop(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test that missing .databricks/config.json is silently ignored."""
+        """Test that missing project config JSON is silently ignored."""
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.chdir(tmp_path)
         monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -607,14 +607,14 @@ class TestDatabricksProjectConfigJson:
         assert config.cluster_id == "json-cluster"
         assert config.mcp_profile == "json-profile"
 
-    def test_load_from_legacy_databricks_config_json(
+    def test_generic_databricks_config_json_is_not_project_routing_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Test loading from legacy .databricks/config.json fallback."""
+        """Test .databricks/config.json is not read as project routing config."""
         config_dir = tmp_path / ".databricks"
         config_dir.mkdir()
         (config_dir / "config.json").write_text(
-            '{"mcp_profile": "legacy-profile", "cluster_id": "legacy-cluster"}'
+            '{"mcp_profile": "generic-profile", "cluster_id": "generic-cluster"}'
         )
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.chdir(tmp_path)
@@ -622,29 +622,8 @@ class TestDatabricksProjectConfigJson:
         monkeypatch.delenv("DATABRICKS_MCP_PROFILE", raising=False)
 
         config = Config.load()
-        assert config.cluster_id == "legacy-cluster"
-        assert config.mcp_profile == "legacy-profile"
-
-    def test_canonical_project_config_overrides_legacy_config_json(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Test canonical project config is preferred over legacy config.json."""
-        config_dir = tmp_path / ".databricks"
-        config_dir.mkdir()
-        (config_dir / "config.json").write_text(
-            '{"mcp_profile": "legacy-profile", "cluster_id": "legacy-cluster"}'
-        )
-        (config_dir / "jupyter-databricks-kernel.json").write_text(
-            '{"mcp_profile": "canonical-profile", "cluster_id": "canonical-cluster"}'
-        )
-        monkeypatch.setattr(Path, "home", lambda: tmp_path)
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)
-        monkeypatch.delenv("DATABRICKS_MCP_PROFILE", raising=False)
-
-        config = Config.load()
-        assert config.cluster_id == "canonical-cluster"
-        assert config.mcp_profile == "canonical-profile"
+        assert config.cluster_id is None
+        assert config.mcp_profile is None
 
     def test_workspace_url_raises_value_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Closes #224

## Summary

Documents the intended usage pattern for `jupyter-databricks-kernel` as the execution engine behind an MCP (Model Context Protocol) server.

Key points documented:
- One MCP server per workspace deployment model
- Per-project `.databricks/config.json` with `mcp_profile` + `cluster_id` (no `workspace_url`)
- AI execution flow: config read → MCP call → `DatabricksExecutor` → output written to `outputs/<filename>.output.md`
- Multi-workspace UX via named profiles

## Runner CLI

With the runner CLI now available (merged in #223), AI agents can also invoke execution directly from the terminal without a Jupyter kernel — complementing the MCP tool interface:

- `uv run run-py <file.py>` — run a plain Python script
- `uv run run-db-py <file.py>` — run a Databricks .py notebook
- `uv run run-ipynb <file.ipynb>` — run a Jupyter notebook

All commands write output to `<output-dir>/<filename>.<timestamp>.output.md` (default: `.cache/outputs/`).
Flags: `--output-dir DIR`, `--timeout SECONDS`, `--inplace` (ipynb only).
