### PR TITLE
refactor(sync): simplify extraction path to /tmp/<project> on cluster driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,9 @@ The extraction directory can also be set via the
 priority over `pyproject.toml`.
 
 By default, files are extracted to
-`/Workspace/Users/<your-user>/jupyter_databricks_kernel/<session>/` on the
-cluster driver node. This is a cluster-local path, not the Databricks UI
-Workspace file browser. A fallback path under `/tmp/` is used for service
-principals or when workspace permissions are denied.
+`/tmp/jupyter_databricks_kernel/<project>/` on the cluster driver node,
+where `<project>` is derived from the local project root directory name.
+This single path works uniformly for user accounts and service principals.
 
 [sdk-auth]: https://docs.databricks.com/en/dev-tools/sdk-python.html#authentication
 [vscode-jupyter]: https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter

--- a/README.md
+++ b/README.md
@@ -149,9 +149,11 @@ The extraction directory can also be set via the
 priority over `pyproject.toml`.
 
 By default, files are extracted to
-`/tmp/jupyter_databricks_kernel/<project>/` on the cluster driver node,
-where `<project>` is derived from the local project root directory name.
-This single path works uniformly for user accounts and service principals.
+`/tmp/jupyter_databricks_kernel/<project>-<hash>/` on the cluster driver node,
+where `<project>` is derived from the local project root directory name and
+`<hash>` is derived from the project root path. This single path works
+uniformly for user accounts and service principals while avoiding collisions
+between different projects with the same directory name.
 
 [sdk-auth]: https://docs.databricks.com/en/dev-tools/sdk-python.html#authentication
 [vscode-jupyter]: https://marketplace.visualstudio.com/items?itemName=ms-toolsai.jupyter

--- a/src/jupyter_databricks_kernel/sync.py
+++ b/src/jupyter_databricks_kernel/sync.py
@@ -985,9 +985,7 @@ del _extract_dir, _cluster_zip_path, _local_zip
         from pathlib import Path
 
         project = self._sanitize_path_component(
-            self.config.base_path.name
-            if self.config.base_path
-            else Path.cwd().name
+            self.config.base_path.name if self.config.base_path else Path.cwd().name
         )
         workspace_extract_dir = f"/tmp/jupyter_databricks_kernel/{project}"
 
@@ -1058,5 +1056,3 @@ del _extract_dir, _cluster_zip_path
             except Exception as e:
                 logger.debug("Context cleanup error (ignored): %s", e)
             self._command_context_id = None
-
-

--- a/src/jupyter_databricks_kernel/sync.py
+++ b/src/jupyter_databricks_kernel/sync.py
@@ -395,7 +395,6 @@ class FileSync:
             raise ValueError(f"Invalid session_id format: {session_id}")
         self.session_id = session_id
         self._synced = False
-        self._user_name: str | None = None
         self._pathspec: pathspec.PathSpec | None = None
         self._pathspec_mtime: float = 0.0
         self._file_cache: FileCache | None = None
@@ -430,28 +429,6 @@ class FileSync:
         sanitized = sanitized.strip(". ")
         # Ensure non-empty
         return sanitized or "unknown"
-
-    def _get_user_name(self) -> str:
-        """Get the current user's email/username (sanitized for path safety).
-
-        For service principals, user_name may not exist. Falls back to
-        application_id, display_name, or "unknown" in that order.
-
-        Returns:
-            The sanitized user's email address or identifier.
-        """
-        if self._user_name is None:
-            client = self._ensure_client()
-            me = client.current_user.me()
-            # NOTE: Service principals may not have user_name attribute
-            raw_name = (
-                getattr(me, "user_name", None)
-                or getattr(me, "application_id", None)
-                or getattr(me, "display_name", None)
-                or "unknown"
-            )
-            self._user_name = self._sanitize_path_component(raw_name)
-        return self._user_name
 
     def _get_source_path(self) -> Path:
         """Get the source directory path.
@@ -1005,16 +982,14 @@ del _extract_dir, _cluster_zip_path, _local_zip
                 ),
             ]
 
-        # Use intelligent fallback: try /Workspace/Users/ first,
-        # fallback to /tmp/workspace
-        user_name = self._get_user_name()
-        workspace_extract_dir = (
-            f"/Workspace/Users/{user_name}/jupyter_databricks_kernel/{self.session_id}"
+        from pathlib import Path
+
+        project = self._sanitize_path_component(
+            self.config.base_path.name
+            if self.config.base_path
+            else Path.cwd().name
         )
-        # NOTE: Use /workspace suffix to avoid confusion with zip path
-        fallback_extract_dir = (
-            f"/tmp/jupyter_databricks_kernel_{self.session_id}/workspace"
-        )
+        workspace_extract_dir = f"/tmp/jupyter_databricks_kernel/{project}"
 
         return [
             (
@@ -1024,59 +999,42 @@ import sys
 import zipfile
 import os
 import shutil
-import logging
 
-_logger = logging.getLogger("jupyter_databricks_kernel")
+_extract_dir = "{workspace_extract_dir}"
+_cluster_zip_path = "{cluster_zip_path}"
 
-# Try /Workspace/Users/ first, fallback to /tmp/workspace if it fails
-_primary_dir = "{workspace_extract_dir}"
-_fallback_dir = "{fallback_extract_dir}"
-
-try:
-    if os.path.exists(_primary_dir):
-        shutil.rmtree(_primary_dir)
-    os.makedirs(_primary_dir, exist_ok=True)
-    _extract_dir = _primary_dir
-except (OSError, PermissionError, FileNotFoundError) as e:
-    # Fallback to /tmp/workspace for service principals or permission issues
-    _logger.info(
-        f"Failed to create {{_primary_dir}}: {{e.__class__.__name__}}: {{e}}. "
-        f"Falling back to {{_fallback_dir}}"
-    )
-    if os.path.exists(_fallback_dir):
-        shutil.rmtree(_fallback_dir)
-    os.makedirs(_fallback_dir, exist_ok=True)
-    _extract_dir = _fallback_dir
+if os.path.exists(_extract_dir):
+    shutil.rmtree(_extract_dir)
+os.makedirs(_extract_dir, mode=0o700, exist_ok=True)
 ''',
             ),
             (
                 "Extracting files",
-                f"""
-# Zip is already on cluster at {cluster_zip_path}
-_cluster_zip = "{cluster_zip_path}"
-with zipfile.ZipFile(_cluster_zip, 'r') as zf:
+                f'''
+_extract_dir = "{workspace_extract_dir}"
+_cluster_zip_path = "{cluster_zip_path}"
+with zipfile.ZipFile(_cluster_zip_path, 'r') as zf:
     zf.extractall(_extract_dir)
-# NOTE: Keep zip file for potential reconnection scenarios
-""",
+''',
             ),
             (
                 "Configuring paths",
-                """
+                f'''
+_extract_dir = "{workspace_extract_dir}"
 if _extract_dir not in sys.path:
     sys.path.insert(0, _extract_dir)
 os.chdir(_extract_dir)
-del _extract_dir, _primary_dir, _fallback_dir, _logger
-""",
+del _extract_dir, _cluster_zip_path
+''',
             ),
         ]
 
     def cleanup(self) -> None:
-        """Clean up DBFS and Workspace files.
+        """Clean up DBFS files and command execution context.
 
-        Note: This method cleans up DBFS and Workspace paths. Local filesystem
-        paths (like /tmp/ on the cluster) are not cleaned up as they are
-        inaccessible from the kernel side and typically get cleaned up
-        automatically or overwritten in subsequent sessions.
+        Note: The /tmp/jupyter_databricks_kernel/<project>/ path on the cluster
+        driver is not cleaned up here as it is inaccessible from the kernel side
+        and gets overwritten on the next sync.
         """
         if not self._synced:
             return
@@ -1088,19 +1046,6 @@ del _extract_dir, _primary_dir, _fallback_dir, _logger
             client.dbfs.delete(dbfs_dir, recursive=True)
         except Exception as e:
             logger.debug("DBFS cleanup error (ignored): %s", e)
-
-        # Clean up Workspace directory if user_name is known
-        # This handles the primary path for regular users
-        if self._user_name is not None:
-            workspace_dir = (
-                f"/Workspace/Users/{self._user_name}"
-                f"/jupyter_databricks_kernel/{self.session_id}"
-            )
-            try:
-                client = self._ensure_client()
-                client.workspace.delete(workspace_dir, recursive=True)
-            except Exception as e:
-                logger.debug("Workspace cleanup error (ignored): %s", e)
 
         # Clean up self-managed command execution context
         if self._command_context_id and self.config.cluster_id:
@@ -1114,9 +1059,4 @@ del _extract_dir, _primary_dir, _fallback_dir, _logger
                 logger.debug("Context cleanup error (ignored): %s", e)
             self._command_context_id = None
 
-        # NOTE: Local filesystem paths used by Command API transfer
-        # (e.g., /tmp/jupyter_databricks_kernel_{session_id}/)
-        # are not cleaned up here as they require an active
-        # execution context. These should be cleaned up via Command API execution
-        # when the executor context is available. Files in /tmp/ are typically
-        # cleaned up automatically by the cluster or overwritten in subsequent sessions.
+

--- a/src/jupyter_databricks_kernel/sync.py
+++ b/src/jupyter_databricks_kernel/sync.py
@@ -984,10 +984,12 @@ del _extract_dir, _cluster_zip_path, _local_zip
 
         from pathlib import Path
 
-        project = self._sanitize_path_component(
-            self.config.base_path.name if self.config.base_path else Path.cwd().name
+        project_root = self.config.base_path if self.config.base_path else Path.cwd()
+        project = self._sanitize_path_component(project_root.name)
+        project_hash = get_project_hash(project_root)
+        workspace_extract_dir = (
+            f"/tmp/jupyter_databricks_kernel/{project}-{project_hash}"
         )
-        workspace_extract_dir = f"/tmp/jupyter_databricks_kernel/{project}"
 
         return [
             (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -75,6 +75,7 @@ def mock_config() -> MagicMock:
     config.sync.max_file_size_mb = None
     config.sync.use_gitignore = True
     config.sync.workspace_extract_dir = None
+    config.base_path = None
 
     return config
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -915,16 +915,12 @@ class TestGetSetupCode:
     def test_setup_code_includes_chdir(self, mock_config: MagicMock) -> None:
         """Test that setup code sets working directory."""
         file_sync = FileSync(mock_config, "test-session")
-        # Mock _get_user_name to avoid Databricks SDK authentication
-        file_sync._get_user_name = MagicMock(return_value="test@example.com")
         setup_code = file_sync.get_setup_code("/tmp/test.zip")
         assert "os.chdir(_extract_dir)" in setup_code
 
     def test_setup_code_includes_sys_path(self, mock_config: MagicMock) -> None:
         """Test that setup code adds to sys.path."""
         file_sync = FileSync(mock_config, "test-session")
-        # Mock _get_user_name to avoid Databricks SDK authentication
-        file_sync._get_user_name = MagicMock(return_value="test@example.com")
         setup_code = file_sync.get_setup_code("/tmp/test.zip")
         assert "sys.path.insert(0, _extract_dir)" in setup_code
 
@@ -1044,28 +1040,25 @@ class TestGetSourcePathWithBasePath:
 class TestGetSetupSteps:
     """Tests for FileSync.get_setup_steps() method."""
 
-    def test_default_fallback_logic(self, mock_file_sync: FileSync) -> None:
-        """Test that fallback logic is included when no custom path is set."""
+    def test_default_tmp_path(self, mock_file_sync: FileSync) -> None:
+        """Test that single /tmp/jupyter_databricks_kernel/<project>/ path is used."""
         cluster_zip_path = "/tmp/test/project.zip"
         steps = mock_file_sync.get_setup_steps(cluster_zip_path)
 
-        # Should return 3 steps (Command API method: no DBFS copy step)
+        # Should return 3 steps
         assert len(steps) == 3
         assert steps[0][0] == "Preparing directory"
         assert steps[1][0] == "Extracting files"
         assert steps[2][0] == "Configuring paths"
 
-        # Check that first step includes fallback logic
+        # Check single path — no fallback logic
         prepare_code = steps[0][1]
-        assert "_primary_dir" in prepare_code
-        assert "_fallback_dir" in prepare_code
-        assert "/Workspace/Users/" in prepare_code
-        assert "/tmp/jupyter_databricks_kernel_" in prepare_code
-        assert "/workspace" in prepare_code  # Fallback path has /workspace suffix
-        assert "try:" in prepare_code
-        assert "except (OSError, PermissionError, FileNotFoundError)" in prepare_code
-        assert "logging" in prepare_code  # INFO level logging
-        assert "_logger.info" in prepare_code
+        assert "/tmp/jupyter_databricks_kernel/" in prepare_code
+        assert "_primary_dir" not in prepare_code
+        assert "_fallback_dir" not in prepare_code
+        assert "/Workspace/Users/" not in prepare_code
+        assert "try:" not in prepare_code
+        assert "except" not in prepare_code
 
     def test_custom_workspace_extract_dir(self, mock_file_sync: FileSync) -> None:
         """Test that custom workspace_extract_dir is used when configured."""
@@ -1086,14 +1079,16 @@ class TestGetSetupSteps:
         assert "_fallback_dir" not in prepare_code
         assert "try:" not in prepare_code
 
-    def test_session_id_in_paths(self, mock_file_sync: FileSync) -> None:
-        """Test that session ID is included in generated paths."""
+    def test_default_path_is_deterministic(self, mock_file_sync: FileSync) -> None:
+        """Test that default path is deterministic (no session UUID in path)."""
         cluster_zip_path = "/tmp/test/project.zip"
         steps = mock_file_sync.get_setup_steps(cluster_zip_path)
 
         prepare_code = steps[0][1]
-        # Session ID should be in both primary and fallback paths
-        assert "test-session-id" in prepare_code
+        # Session ID must NOT appear in default path — path is project-scoped
+        assert "test-session-id" not in prepare_code
+        # Path must be under /tmp/jupyter_databricks_kernel/
+        assert "/tmp/jupyter_databricks_kernel/" in prepare_code
 
     def test_cluster_zip_path_in_code(self, mock_file_sync: FileSync) -> None:
         """Test that zip path is correctly embedded in generated code."""
@@ -1105,90 +1100,6 @@ class TestGetSetupSteps:
         extract_code = steps[1][1]
         assert cluster_zip_path in extract_code
         assert "_cluster_zip" in extract_code
-
-
-class TestGetUserName:
-    """Tests for FileSync._get_user_name() method with service principal support."""
-
-    def test_regular_user_with_user_name(
-        self, mock_config: MagicMock, mock_workspace_client: MagicMock
-    ) -> None:
-        """Test that user_name is used when available."""
-        file_sync = FileSync(mock_config, "test-session", client=mock_workspace_client)
-
-        # Regular user has user_name
-        mock_workspace_client.current_user.me.return_value.user_name = (
-            "user@example.com"
-        )
-
-        user_name = file_sync._get_user_name()
-        assert user_name == "user@example.com"
-
-    def test_service_principal_with_application_id(
-        self, mock_config: MagicMock, mock_workspace_client: MagicMock
-    ) -> None:
-        """Test that application_id is used when user_name is not available."""
-        file_sync = FileSync(mock_config, "test-session", client=mock_workspace_client)
-
-        # Service principal has application_id but no user_name
-        me_mock = MagicMock()
-        me_mock.user_name = None
-        me_mock.application_id = "12345678-1234-1234-1234-123456789abc"
-        mock_workspace_client.current_user.me.return_value = me_mock
-
-        user_name = file_sync._get_user_name()
-        assert user_name == "12345678-1234-1234-1234-123456789abc"
-
-    def test_service_principal_with_display_name(
-        self, mock_config: MagicMock, mock_workspace_client: MagicMock
-    ) -> None:
-        """Test that display_name is used as fallback."""
-        file_sync = FileSync(mock_config, "test-session", client=mock_workspace_client)
-
-        # Service principal has display_name but no user_name or application_id
-        me_mock = MagicMock()
-        me_mock.user_name = None
-        me_mock.application_id = None
-        me_mock.display_name = "My Service Principal"
-        mock_workspace_client.current_user.me.return_value = me_mock
-
-        user_name = file_sync._get_user_name()
-        assert user_name == "My_Service_Principal"  # Sanitized
-
-    def test_service_principal_no_attributes(
-        self, mock_config: MagicMock, mock_workspace_client: MagicMock
-    ) -> None:
-        """Test that 'unknown' is used when no attributes are available."""
-        file_sync = FileSync(mock_config, "test-session", client=mock_workspace_client)
-
-        # Service principal has no identifying attributes
-        me_mock = MagicMock()
-        me_mock.user_name = None
-        me_mock.application_id = None
-        me_mock.display_name = None
-        mock_workspace_client.current_user.me.return_value = me_mock
-
-        user_name = file_sync._get_user_name()
-        assert user_name == "unknown"
-
-    def test_user_name_cached(
-        self, mock_config: MagicMock, mock_workspace_client: MagicMock
-    ) -> None:
-        """Test that user_name is cached after first call."""
-        file_sync = FileSync(mock_config, "test-session", client=mock_workspace_client)
-
-        mock_workspace_client.current_user.me.return_value.user_name = (
-            "user@example.com"
-        )
-
-        # First call
-        user_name1 = file_sync._get_user_name()
-        # Second call
-        user_name2 = file_sync._get_user_name()
-
-        assert user_name1 == user_name2
-        # me() should be called only once due to caching
-        assert mock_workspace_client.current_user.me.call_count == 1
 
 
 class TestCommandAPITransfer:

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1090,6 +1090,44 @@ class TestGetSetupSteps:
         # Path must be under /tmp/jupyter_databricks_kernel/
         assert "/tmp/jupyter_databricks_kernel/" in prepare_code
 
+    def test_default_path_includes_project_hash(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test that default path includes a project-root hash."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        mock_config.base_path = project_root
+        file_sync = FileSync(mock_config, "test-session-id")
+
+        steps = file_sync.get_setup_steps("/tmp/test/project.zip")
+
+        prepare_code = steps[0][1]
+        expected_path = (
+            f"/tmp/jupyter_databricks_kernel/project-{get_project_hash(project_root)}"
+        )
+        assert expected_path in prepare_code
+
+    def test_same_project_names_get_distinct_default_paths(
+        self, mock_config: MagicMock, tmp_path: Path
+    ) -> None:
+        """Test that same-name project roots do not share default paths."""
+        first_root = tmp_path / "first" / "project"
+        second_root = tmp_path / "second" / "project"
+        first_root.mkdir(parents=True)
+        second_root.mkdir(parents=True)
+
+        mock_config.base_path = first_root
+        first_sync = FileSync(mock_config, "first-session")
+        first_prepare_code = first_sync.get_setup_steps("/tmp/test/project.zip")[0][1]
+
+        mock_config.base_path = second_root
+        second_sync = FileSync(mock_config, "second-session")
+        second_prepare_code = second_sync.get_setup_steps("/tmp/test/project.zip")[0][1]
+
+        assert f"project-{get_project_hash(first_root)}" in first_prepare_code
+        assert f"project-{get_project_hash(second_root)}" in second_prepare_code
+        assert first_prepare_code != second_prepare_code
+
     def test_cluster_zip_path_in_code(self, mock_file_sync: FileSync) -> None:
         """Test that zip path is correctly embedded in generated code."""
         cluster_zip_path = "/tmp/test/project.zip"


### PR DESCRIPTION
Closes #237

## Summary

Replaces the dual-path extraction logic (`/Workspace/Users/<user>/...` with `/tmp/` fallback) with a single default: `/tmp/jupyter_databricks_kernel/<project>/`.

## Changes

- Default extraction path is `/tmp/jupyter_databricks_kernel/<project>/` where `<project>` is derived from the local project root
- `workspace_extract_dir` config option still overrides the default
- `JUPYTER_DATABRICKS_KERNEL_EXTRACT_DIR` env var still takes priority
- Fallback `/tmp/` path logic for service principals removed (single code path)
- README updated to reflect new default path