### PR TITLE
feat: runner.py redesign — CLI runner layer, .databricks/config.json schema, MCP server integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,9 @@ __marimo__/
 # Databricks kernel cache
 .jupyter-databricks-kernel-cache.json
 
+# Runner CLI output artifacts
+outputs/
+
 # hatch-vcs generated version file
 src/jupyter_databricks_kernel/_version.py
 

--- a/README.md
+++ b/README.md
@@ -201,13 +201,16 @@ uv run run-db-py path/to/notebook.py
 uv run run-ipynb path/to/notebook.ipynb
 ```
 
-Output is written to `outputs/<filename>.output.md` relative to the current
-working directory.
+Output is written to `.cache/outputs/<stem>.<YYYYMMDDTHHMMSS>.output.md`
+relative to the current working directory. Use `--output-dir` to override the
+directory.
 
 #### Behavior notes
 
 | Behavior | Details |
 | --- | --- |
+| Default output dir | `.cache/outputs/` (override with `--output-dir DIR`) |
+| Output filename | `<stem>.<YYYYMMDDTHHMMSS>.output.md` — timestamped, never overwritten |
 | Default timeout | 10 minutes per command/cell |
 | Timeout handling | Cluster command is cancelled; error written to output file |
 | Exit code | Exits with code 1 on error or timeout; code 0 on success |

--- a/README.md
+++ b/README.md
@@ -204,6 +204,15 @@ uv run run-ipynb path/to/notebook.ipynb
 Output is written to `outputs/<filename>.output.md` relative to the current
 working directory.
 
+#### Behavior notes
+
+| Behavior | Details |
+| --- | --- |
+| Default timeout | 10 minutes per command/cell |
+| Timeout handling | Cluster command is cancelled; error written to output file |
+| Exit code | Exits with code 1 on error or timeout; code 0 on success |
+| `run-ipynb --inplace` | Writes cell outputs back into the notebook; backup at `<path>.bak` |
+
 ## 6. Papermill Integration
 
 [papermill](https://papermill.readthedocs.io/) supports parameter injection for

--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ If the cluster is stopped, kernel startup may take 5-6 minutes. Increase
 jupyter execute notebook.ipynb --kernel_name=databricks --startup_timeout=600
 ```
 
+### 5.3. Runner CLI (`run-py`, `run-db-py`, `run-ipynb`)
+
+Execute scripts and notebooks directly without launching Jupyter:
+
+```bash
+uv run run-py path/to/script.py
+uv run run-db-py path/to/notebook.py
+uv run run-ipynb path/to/notebook.ipynb
+```
+
+Output is written to `outputs/<filename>.output.md` relative to the current
+working directory.
+
 ## 6. Papermill Integration
 
 [papermill](https://papermill.readthedocs.io/) supports parameter injection for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,11 @@ dependencies = [
     "pathspec>=0.11.0",
 ]
 
+[project.scripts]
+run-py    = "jupyter_databricks_kernel.runner:cli_run_py"
+run-db-py = "jupyter_databricks_kernel.runner:cli_run_db_py"
+run-ipynb = "jupyter_databricks_kernel.runner:cli_run_ipynb"
+
 [dependency-groups]
 dev = [
     "jupyterlab>=4.0.0",

--- a/src/jupyter_databricks_kernel/config.py
+++ b/src/jupyter_databricks_kernel/config.py
@@ -132,7 +132,8 @@ class Config:
             )
 
         logger.debug(
-            "Configuration loaded: cluster_id=%s, mcp_profile=%s, sync_enabled=%s, base_path=%s",
+            "Configuration loaded: cluster_id=%s, mcp_profile=%s,"
+            " sync_enabled=%s, base_path=%s",
             config.cluster_id,
             config.mcp_profile,
             config.sync.enabled,

--- a/src/jupyter_databricks_kernel/config.py
+++ b/src/jupyter_databricks_kernel/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import configparser
+import json
 import logging
 import os
 import tomllib
@@ -35,6 +36,7 @@ class Config:
     """Main configuration for the Databricks kernel."""
 
     cluster_id: str | None = None
+    mcp_profile: str | None = None
     sync: SyncConfig = field(default_factory=SyncConfig)
     base_path: Path | None = None
 
@@ -57,13 +59,29 @@ class Config:
         logger.debug("No pyproject.toml found in %s or parent directories", current)
         return None
 
+    @staticmethod
+    def _find_databricks_config_json() -> Path | None:
+        """Find .databricks/config.json in current or parent directories.
+
+        Returns:
+            Path to .databricks/config.json if found, None otherwise.
+        """
+        current = Path.cwd()
+        for directory in [current] + list(current.parents):
+            candidate = directory / ".databricks" / "config.json"
+            if candidate.exists():
+                logger.debug("Found .databricks/config.json at %s", candidate)
+                return candidate
+        return None
+
     @classmethod
     def load(cls, config_path: Path | None = None) -> Config:
         """Load configuration from environment variables and config files.
 
-        Priority order for cluster_id:
-        1. DATABRICKS_CLUSTER_ID environment variable (highest priority)
-        2. ~/.databrickscfg cluster_id (from active profile)
+        Priority order for cluster_id and mcp_profile:
+        1. Environment variables (highest priority)
+        2. ~/.databrickscfg (from active profile)
+        3. .databricks/config.json (project-local, lowest priority)
 
         Sync settings are loaded from pyproject.toml.
 
@@ -77,14 +95,24 @@ class Config:
         logger.debug("Loading configuration")
         config = cls()
 
-        # Load cluster_id from environment variable (highest priority)
+        # Load from environment variables (highest priority)
         config.cluster_id = os.environ.get("DATABRICKS_CLUSTER_ID")
         if config.cluster_id:
             logger.debug("Cluster ID from environment: %s", config.cluster_id)
 
-        # Load cluster_id from databrickscfg if not set by env var
-        if config.cluster_id is None:
-            config._load_cluster_id_from_databrickscfg()
+        config.mcp_profile = os.environ.get("DATABRICKS_MCP_PROFILE")
+        if config.mcp_profile:
+            logger.debug("MCP profile from environment: %s", config.mcp_profile)
+
+        # Load from databrickscfg if fields not set by env var
+        if config.cluster_id is None or config.mcp_profile is None:
+            config._load_from_databrickscfg()
+
+        # Load from .databricks/config.json if fields still not set
+        if config.cluster_id is None or config.mcp_profile is None:
+            databricks_config = cls._find_databricks_config_json()
+            if databricks_config is not None:
+                config._load_from_databricks_config_json(databricks_config)
 
         # Search for pyproject.toml if not explicitly provided
         if config_path is None:
@@ -104,17 +132,18 @@ class Config:
             )
 
         logger.debug(
-            "Configuration loaded: cluster_id=%s, sync_enabled=%s, base_path=%s",
+            "Configuration loaded: cluster_id=%s, mcp_profile=%s, sync_enabled=%s, base_path=%s",
             config.cluster_id,
+            config.mcp_profile,
             config.sync.enabled,
             config.base_path,
         )
         return config
 
-    def _load_cluster_id_from_databrickscfg(self) -> None:
-        """Load cluster_id from ~/.databrickscfg.
+    def _load_from_databrickscfg(self) -> None:
+        """Load cluster_id and mcp_profile from ~/.databrickscfg.
 
-        Reads cluster_id from the active profile in ~/.databrickscfg.
+        Reads values from the active profile in ~/.databrickscfg.
         Active profile is determined by DATABRICKS_CONFIG_PROFILE
         environment variable, or 'DEFAULT' if not set.
         """
@@ -134,11 +163,49 @@ class Config:
         if profile not in parser:
             return
 
-        if "cluster_id" in parser[profile]:
+        if self.cluster_id is None and "cluster_id" in parser[profile]:
             self.cluster_id = parser[profile]["cluster_id"]
             logger.debug(
                 "Cluster ID from databrickscfg [%s]: %s", profile, self.cluster_id
             )
+
+        if self.mcp_profile is None and "mcp_profile" in parser[profile]:
+            self.mcp_profile = parser[profile]["mcp_profile"]
+            logger.debug(
+                "MCP profile from databrickscfg [%s]: %s", profile, self.mcp_profile
+            )
+
+    def _load_from_databricks_config_json(self, path: Path) -> None:
+        """Load cluster_id and mcp_profile from .databricks/config.json.
+
+        Args:
+            path: Path to .databricks/config.json.
+
+        Raises:
+            ValueError: If config contains workspace_url (intentionally absent
+                from schema; workspace identity must come from mcp_profile).
+        """
+        logger.debug("Loading from %s", path)
+        try:
+            with open(path) as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError) as e:
+            logger.warning("Failed to parse %s: %s", path, e)
+            return
+
+        if "workspace_url" in data:
+            raise ValueError(
+                f"{path} must not contain 'workspace_url'. "
+                "Workspace identity must come from mcp_profile in ~/.databrickscfg."
+            )
+
+        if self.cluster_id is None and "cluster_id" in data:
+            self.cluster_id = data["cluster_id"]
+            logger.debug("Cluster ID from %s: %s", path, self.cluster_id)
+
+        if self.mcp_profile is None and "mcp_profile" in data:
+            self.mcp_profile = data["mcp_profile"]
+            logger.debug("MCP profile from %s: %s", path, self.mcp_profile)
 
     def _load_from_pyproject(self, config_path: Path) -> None:
         """Load sync configuration from pyproject.toml.

--- a/src/jupyter_databricks_kernel/executor.py
+++ b/src/jupyter_databricks_kernel/executor.py
@@ -203,6 +203,7 @@ class DatabricksExecutor:
         *,
         allow_reconnect: bool = True,
         on_progress: ProgressCallback | None = None,
+        timeout: timedelta | None = None,
     ) -> ExecutionResult:
         """Execute code on the Databricks cluster.
 
@@ -211,6 +212,7 @@ class DatabricksExecutor:
             allow_reconnect: If True, attempt to reconnect on context errors.
             on_progress: Optional callback for progress updates.
                 Called with (cluster_state, command_status, elapsed_seconds).
+            timeout: Execution timeout (default: COMMAND_EXECUTION_TIMEOUT).
 
         Returns:
             Execution result containing output or error.
@@ -232,9 +234,9 @@ class DatabricksExecutor:
 
         try:
             if on_progress:
-                result = self._execute_with_polling(code, on_progress)
+                result = self._execute_with_polling(code, on_progress, timeout=timeout)
             else:
-                result = self._execute_internal(code)
+                result = self._execute_internal(code, timeout=timeout)
             return result
         except Exception as e:
             if allow_reconnect and self._is_context_invalid_error(e):
@@ -244,9 +246,11 @@ class DatabricksExecutor:
                     time.sleep(RECONNECT_DELAY_SECONDS)
                     self.reconnect()
                     if on_progress:
-                        result = self._execute_with_polling(code, on_progress)
+                        result = self._execute_with_polling(
+                            code, on_progress, timeout=timeout
+                        )
                     else:
-                        result = self._execute_internal(code)
+                        result = self._execute_internal(code, timeout=timeout)
                     return replace(result, reconnected=True)
                 except Exception as retry_error:
                     logger.error("Reconnection failed: %s", retry_error)
@@ -261,11 +265,14 @@ class DatabricksExecutor:
                     error=str(e),
                 )
 
-    def _execute_internal(self, code: str) -> ExecutionResult:
+    def _execute_internal(
+        self, code: str, timeout: timedelta | None = None
+    ) -> ExecutionResult:
         """Internal execution without reconnection logic.
 
         Args:
             code: The Python code to execute.
+            timeout: Execution timeout (default: COMMAND_EXECUTION_TIMEOUT).
 
         Returns:
             Execution result containing output or error.
@@ -280,8 +287,9 @@ class DatabricksExecutor:
             language=compute.Language.PYTHON,
             command=code,
         )
+        effective_timeout = timeout or COMMAND_EXECUTION_TIMEOUT
         try:
-            response = waiter.result(timeout=COMMAND_EXECUTION_TIMEOUT)
+            response = waiter.result(timeout=effective_timeout)
         except TimeoutError:
             try:
                 client.command_execution.cancel(
@@ -361,12 +369,14 @@ class DatabricksExecutor:
         self,
         code: str,
         on_progress: ProgressCallback,
+        timeout: timedelta | None = None,
     ) -> ExecutionResult:
         """Execute code with polling for progress updates.
 
         Args:
             code: The Python code to execute.
             on_progress: Callback for progress updates.
+            timeout: Execution timeout (default: COMMAND_EXECUTION_TIMEOUT).
 
         Returns:
             Execution result containing output or error.
@@ -377,7 +387,7 @@ class DatabricksExecutor:
         """
         client = self._ensure_client()
         start_time = time.time()
-        timeout_seconds = COMMAND_EXECUTION_TIMEOUT.total_seconds()
+        timeout_seconds = (timeout or COMMAND_EXECUTION_TIMEOUT).total_seconds()
 
         # Start execution without blocking
         waiter = client.command_execution.execute(

--- a/src/jupyter_databricks_kernel/executor.py
+++ b/src/jupyter_databricks_kernel/executor.py
@@ -274,12 +274,24 @@ class DatabricksExecutor:
             Exception: If execution fails due to API errors.
         """
         client = self._ensure_client()
-        response = client.command_execution.execute(
+        waiter = client.command_execution.execute(
             cluster_id=self.config.cluster_id,
             context_id=self.context_id,
             language=compute.Language.PYTHON,
             command=code,
-        ).result(timeout=COMMAND_EXECUTION_TIMEOUT)
+        )
+        try:
+            response = waiter.result(timeout=COMMAND_EXECUTION_TIMEOUT)
+        except TimeoutError:
+            try:
+                client.command_execution.cancel(
+                    cluster_id=self.config.cluster_id,
+                    context_id=self.context_id,
+                    command_id=waiter.command_id,
+                )
+            except Exception:
+                pass
+            raise
 
         if response is None:
             return ExecutionResult(

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -170,20 +170,23 @@ def _run_ipynb_inplace(path: Path, executor: DatabricksExecutor) -> ExecutionRes
         raise
 
 
-def write_output(result: ExecutionResult, path: Path) -> Path:
-    """Write an ExecutionResult to outputs/<path.stem>.output.md.
+def write_output(
+    result: ExecutionResult, path: Path, output_dir: str = "outputs"
+) -> Path:
+    """Write an ExecutionResult to <output_dir>/<path.stem>.output.md.
 
-    The outputs/ directory is created relative to CWD if it does not exist.
+    The output directory is created (including parents) if it does not exist.
 
     Args:
         result: The ExecutionResult to write.
         path: The source file path (used to derive the output filename).
+        output_dir: Directory to write output file into (default: "outputs").
 
     Returns:
         Path to the written output file.
     """
-    outputs_dir = Path("outputs")
-    outputs_dir.mkdir(exist_ok=True)
+    outputs_dir = Path(output_dir)
+    outputs_dir.mkdir(parents=True, exist_ok=True)
     out_path = outputs_dir / f"{path.stem}.output.md"
 
     lines: list[str] = [
@@ -206,14 +209,21 @@ def _cli_dispatch(subcommand: str) -> None:
     """Shared dispatch logic for CLI entry points.
 
     Args:
-        subcommand: One of 'run_py', 'run_db_py', 'run_ipynb'.
+        subcommand: One of 'run_py', 'run_db_py'.
     """
+    import argparse
     import sys
 
     from .config import Config
     from .executor import DatabricksExecutor
 
-    file_path = Path(sys.argv[1])
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file")
+    parser.add_argument("--output-dir", default="outputs")
+    parsed = parser.parse_args()
+    file_path = Path(parsed.file)
+    output_dir = parsed.output_dir
+
     config = Config.load()
     executor = DatabricksExecutor(config)
     executor.create_context()
@@ -222,7 +232,7 @@ def _cli_dispatch(subcommand: str) -> None:
             subcommand
         ]
         result = fn(file_path, executor)
-        write_output(result, file_path)
+        write_output(result, file_path, output_dir)
     finally:
         executor.destroy_context()
     if result.status == "error":
@@ -232,10 +242,12 @@ def _cli_dispatch(subcommand: str) -> None:
 def cli_run_py() -> None:
     """CLI entry point for run-py.
 
+    Usage: run-py <path> [--output-dir DIR]
+
     Executes a .py file on the cluster. Output is written to
-    outputs/<stem>.output.md relative to CWD. Default execution timeout is
-    10 minutes; the cluster command is cancelled on timeout. Exits with
-    code 1 on error or timeout.
+    <output-dir>/<stem>.output.md (default output-dir: "outputs"). Default
+    execution timeout is 10 minutes; the cluster command is cancelled on
+    timeout. Exits with code 1 on error or timeout.
     """
     _cli_dispatch("run_py")
 
@@ -243,10 +255,12 @@ def cli_run_py() -> None:
 def cli_run_db_py() -> None:
     """CLI entry point for run-db-py.
 
+    Usage: run-db-py <path> [--output-dir DIR]
+
     Executes a Databricks .py notebook on the cluster. Output is written to
-    outputs/<stem>.output.md relative to CWD. Default execution timeout is
-    10 minutes; the cluster command is cancelled on timeout. Exits with
-    code 1 on error or timeout.
+    <output-dir>/<stem>.output.md (default output-dir: "outputs"). Default
+    execution timeout is 10 minutes; the cluster command is cancelled on
+    timeout. Exits with code 1 on error or timeout.
     """
     _cli_dispatch("run_db_py")
 
@@ -254,25 +268,30 @@ def cli_run_db_py() -> None:
 def cli_run_ipynb() -> None:
     """CLI entry point for run-ipynb.
 
-    Usage: run-ipynb <path> [--inplace]
+    Usage: run-ipynb <path> [--inplace] [--output-dir DIR]
 
     Without --inplace: executes cells and writes combined output to
-    outputs/<stem>.output.md relative to CWD.
+    <output-dir>/<stem>.output.md (default output-dir: "outputs").
     With --inplace: writes cell outputs back into the notebook (backup at
     <path>.bak).
 
     Default execution timeout per cell is 10 minutes; the cluster command is
     cancelled on timeout. Exits with code 1 on error or timeout.
     """
+    import argparse
     import sys
 
     from .config import Config
     from .executor import DatabricksExecutor, ExecutionResult
 
-    args = sys.argv[1:]
-    inplace = "--inplace" in args
-    file_args = [a for a in args if not a.startswith("--")]
-    file_path = Path(file_args[0])
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file")
+    parser.add_argument("--inplace", action="store_true")
+    parser.add_argument("--output-dir", default="outputs")
+    parsed = parser.parse_args()
+    file_path = Path(parsed.file)
+    inplace = parsed.inplace
+    output_dir = parsed.output_dir
 
     config = Config.load()
     executor = DatabricksExecutor(config)
@@ -285,7 +304,7 @@ def cli_run_ipynb() -> None:
                 result = ExecutionResult(status="error", error=str(e))
         else:
             result = run_ipynb(file_path, executor)
-        write_output(result, file_path)
+        write_output(result, file_path, output_dir)
     finally:
         executor.destroy_context()
     if result.status == "error":

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -1,0 +1,215 @@
+"""CLI runner and library interface for Databricks code execution."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .executor import DatabricksExecutor, ExecutionResult
+
+
+def run_py(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
+    """Execute a plain Python file on the Databricks cluster.
+
+    Args:
+        path: Path to the .py file to execute.
+        executor: Initialized DatabricksExecutor with an active context.
+
+    Returns:
+        ExecutionResult from the cluster.
+    """
+    code = path.read_text(encoding="utf-8")
+    return executor.execute(code)
+
+
+def run_db_py(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
+    """Execute a Databricks notebook .py file on the cluster.
+
+    Databricks .py notebooks are valid Python; magic command splitting
+    (e.g. %run, %pip) is deferred to a future milestone.
+
+    Args:
+        path: Path to the Databricks .py notebook file.
+        executor: Initialized DatabricksExecutor with an active context.
+
+    Returns:
+        ExecutionResult from the cluster.
+    """
+    code = path.read_text(encoding="utf-8")
+    return executor.execute(code)
+
+
+def run_ipynb(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
+    """Execute all code cells of a notebook, writing outputs back in-place.
+
+    Saves a backup at <path>.bak before mutating; restores on exception.
+    Returns a summary ExecutionResult combining all cell outputs.
+
+    Args:
+        path: Path to the .ipynb notebook to execute.
+        executor: Initialized DatabricksExecutor with an active context.
+
+    Returns:
+        Summary ExecutionResult with combined output from all cells.
+    """
+    backup = path.with_suffix(path.suffix + ".bak")
+    shutil.copy2(path, backup)
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            notebook: dict[str, Any] = json.load(f)
+
+        cells = notebook.get("cells", [])
+        combined_output: list[str] = []
+        last_result = None
+
+        for cell in cells:
+            if cell.get("cell_type") != "code":
+                continue
+            source = cell.get("source", "")
+            if isinstance(source, list):
+                source = "".join(source)
+            if not source.strip():
+                continue
+
+            result = executor.execute(source)
+            last_result = result
+
+            cell_outputs: list[dict[str, Any]] = []
+            if result.output:
+                combined_output.append(result.output)
+                cell_outputs.append(
+                    {
+                        "output_type": "stream",
+                        "name": "stdout",
+                        "text": result.output,
+                    }
+                )
+            if result.error:
+                combined_output.append(f"ERROR: {result.error}")
+                cell_outputs.append(
+                    {
+                        "output_type": "error",
+                        "ename": "ExecutionError",
+                        "evalue": result.error,
+                        "traceback": result.traceback or [],
+                    }
+                )
+            cell["outputs"] = cell_outputs
+
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(notebook, f, indent=1, ensure_ascii=False)
+
+        backup.unlink()
+
+        from .executor import ExecutionResult
+
+        if last_result is None:
+            return ExecutionResult(status="ok", output="(no code cells)")
+
+        return ExecutionResult(
+            status=last_result.status,
+            output="\n".join(combined_output) if combined_output else None,
+            error=last_result.error,
+        )
+
+    except Exception:
+        shutil.copy2(backup, path)
+        backup.unlink()
+        raise
+
+
+def write_output(result: ExecutionResult, path: Path) -> Path:
+    """Write an ExecutionResult to outputs/<path.stem>.output.md.
+
+    The outputs/ directory is created relative to CWD if it does not exist.
+
+    Args:
+        result: The ExecutionResult to write.
+        path: The source file path (used to derive the output filename).
+
+    Returns:
+        Path to the written output file.
+    """
+    outputs_dir = Path("outputs")
+    outputs_dir.mkdir(exist_ok=True)
+    out_path = outputs_dir / f"{path.stem}.output.md"
+
+    lines: list[str] = [
+        f"# Output: {path.name}",
+        "",
+        f"**Status:** {result.status}",
+    ]
+
+    if result.output is not None:
+        lines += ["", "## Output", "", result.output]
+
+    if result.error is not None:
+        lines += ["", "## Error", "", result.error]
+
+    out_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return out_path
+
+
+def _cli_dispatch(subcommand: str) -> None:
+    """Shared dispatch logic for CLI entry points.
+
+    Args:
+        subcommand: One of 'run_py', 'run_db_py', 'run_ipynb'.
+    """
+    import sys
+
+    from .config import Config
+    from .executor import DatabricksExecutor
+
+    file_path = Path(sys.argv[1])
+    config = Config.load()
+    executor = DatabricksExecutor(config)
+    executor.create_context()
+    try:
+        fn = {"run_py": run_py, "run_db_py": run_db_py, "run_ipynb": run_ipynb}[
+            subcommand
+        ]
+        result = fn(file_path, executor)
+        write_output(result, file_path)
+    finally:
+        executor.destroy_context()
+
+
+def cli_run_py() -> None:
+    """CLI entry point for run-py."""
+    _cli_dispatch("run_py")
+
+
+def cli_run_db_py() -> None:
+    """CLI entry point for run-db-py."""
+    _cli_dispatch("run_db_py")
+
+
+def cli_run_ipynb() -> None:
+    """CLI entry point for run-ipynb."""
+    _cli_dispatch("run_ipynb")
+
+
+if __name__ == "__main__":
+    import sys
+
+    from .config import Config
+    from .executor import DatabricksExecutor
+
+    subcommand = sys.argv[1]
+    file_path = Path(sys.argv[2])
+    config = Config.load()
+    executor = DatabricksExecutor(config)
+    executor.create_context()
+    try:
+        fn = {"run_py": run_py, "run_db_py": run_db_py, "run_ipynb": run_ipynb}[
+            subcommand
+        ]
+        result = fn(file_path, executor)
+        write_output(result, file_path)
+    finally:
+        executor.destroy_context()

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -171,23 +172,24 @@ def _run_ipynb_inplace(path: Path, executor: DatabricksExecutor) -> ExecutionRes
 
 
 def write_output(
-    result: ExecutionResult, path: Path, output_dir: str = "outputs"
+    result: ExecutionResult, path: Path, output_dir: str = ".cache/outputs"
 ) -> Path:
-    """Write an ExecutionResult to <output_dir>/<path.stem>.output.md.
+    """Write an ExecutionResult to <output_dir>/<path.stem>.<timestamp>.output.md.
 
     The output directory is created (including parents) if it does not exist.
 
     Args:
         result: The ExecutionResult to write.
         path: The source file path (used to derive the output filename).
-        output_dir: Directory to write output file into (default: "outputs").
+        output_dir: Directory to write output file into (default: ".cache/outputs").
 
     Returns:
         Path to the written output file.
     """
     outputs_dir = Path(output_dir)
     outputs_dir.mkdir(parents=True, exist_ok=True)
-    out_path = outputs_dir / f"{path.stem}.output.md"
+    timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
+    out_path = outputs_dir / f"{path.stem}.{timestamp}.output.md"
 
     lines: list[str] = [
         f"# Output: {path.name}",
@@ -219,7 +221,7 @@ def _cli_dispatch(subcommand: str) -> None:
 
     parser = argparse.ArgumentParser()
     parser.add_argument("file")
-    parser.add_argument("--output-dir", default="outputs")
+    parser.add_argument("--output-dir", default=".cache/outputs")
     parsed = parser.parse_args()
     file_path = Path(parsed.file)
     output_dir = parsed.output_dir
@@ -245,9 +247,9 @@ def cli_run_py() -> None:
     Usage: run-py <path> [--output-dir DIR]
 
     Executes a .py file on the cluster. Output is written to
-    <output-dir>/<stem>.output.md (default output-dir: "outputs"). Default
-    execution timeout is 10 minutes; the cluster command is cancelled on
-    timeout. Exits with code 1 on error or timeout.
+    <output-dir>/<stem>.<YYYYMMDDTHHMMSS>.output.md (default output-dir:
+    ".cache/outputs"). Default execution timeout is 10 minutes; the cluster
+    command is cancelled on timeout. Exits with code 1 on error or timeout.
     """
     _cli_dispatch("run_py")
 
@@ -258,9 +260,9 @@ def cli_run_db_py() -> None:
     Usage: run-db-py <path> [--output-dir DIR]
 
     Executes a Databricks .py notebook on the cluster. Output is written to
-    <output-dir>/<stem>.output.md (default output-dir: "outputs"). Default
-    execution timeout is 10 minutes; the cluster command is cancelled on
-    timeout. Exits with code 1 on error or timeout.
+    <output-dir>/<stem>.<YYYYMMDDTHHMMSS>.output.md (default output-dir:
+    ".cache/outputs"). Default execution timeout is 10 minutes; the cluster
+    command is cancelled on timeout. Exits with code 1 on error or timeout.
     """
     _cli_dispatch("run_db_py")
 
@@ -271,7 +273,8 @@ def cli_run_ipynb() -> None:
     Usage: run-ipynb <path> [--inplace] [--output-dir DIR]
 
     Without --inplace: executes cells and writes combined output to
-    <output-dir>/<stem>.output.md (default output-dir: "outputs").
+    <output-dir>/<stem>.<YYYYMMDDTHHMMSS>.output.md (default output-dir:
+    ".cache/outputs").
     With --inplace: writes cell outputs back into the notebook (backup at
     <path>.bak).
 
@@ -287,7 +290,7 @@ def cli_run_ipynb() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("file")
     parser.add_argument("--inplace", action="store_true")
-    parser.add_argument("--output-dir", default="outputs")
+    parser.add_argument("--output-dir", default=".cache/outputs")
     parsed = parser.parse_args()
     file_path = Path(parsed.file)
     inplace = parsed.inplace

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -12,21 +12,30 @@ if TYPE_CHECKING:
     from .executor import DatabricksExecutor, ExecutionResult
 
 
-def run_py(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
+def run_py(
+    path: Path,
+    executor: DatabricksExecutor,
+    timeout: timedelta | None = None,
+) -> ExecutionResult:
     """Execute a plain Python file on the Databricks cluster.
 
     Args:
         path: Path to the .py file to execute.
         executor: Initialized DatabricksExecutor with an active context.
+        timeout: Execution timeout (default: COMMAND_EXECUTION_TIMEOUT).
 
     Returns:
         ExecutionResult from the cluster.
     """
     code = path.read_text(encoding="utf-8")
-    return executor.execute(code)
+    return executor.execute(code, timeout=timeout)
 
 
-def run_db_py(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
+def run_db_py(
+    path: Path,
+    executor: DatabricksExecutor,
+    timeout: timedelta | None = None,
+) -> ExecutionResult:
     """Execute a Databricks notebook .py file on the cluster.
 
     Databricks .py notebooks are valid Python; magic command splitting
@@ -35,15 +44,20 @@ def run_db_py(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
     Args:
         path: Path to the Databricks .py notebook file.
         executor: Initialized DatabricksExecutor with an active context.
+        timeout: Execution timeout (default: COMMAND_EXECUTION_TIMEOUT).
 
     Returns:
         ExecutionResult from the cluster.
     """
     code = path.read_text(encoding="utf-8")
-    return executor.execute(code)
+    return executor.execute(code, timeout=timeout)
 
 
-def run_ipynb(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
+def run_ipynb(
+    path: Path,
+    executor: DatabricksExecutor,
+    timeout: timedelta | None = None,
+) -> ExecutionResult:
     """Execute all code cells of a notebook and return combined output.
 
     Does NOT modify the notebook file. Use cli_run_ipynb with --inplace to
@@ -52,6 +66,7 @@ def run_ipynb(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
     Args:
         path: Path to the .ipynb notebook to execute.
         executor: Initialized DatabricksExecutor with an active context.
+        timeout: Execution timeout per cell (default: COMMAND_EXECUTION_TIMEOUT).
 
     Returns:
         Summary ExecutionResult with combined output from all cells.
@@ -72,7 +87,7 @@ def run_ipynb(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
         if not source.strip():
             continue
 
-        result = executor.execute(source)
+        result = executor.execute(source, timeout=timeout)
         last_result = result
 
         if result.output:
@@ -92,7 +107,11 @@ def run_ipynb(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
     )
 
 
-def _run_ipynb_inplace(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
+def _run_ipynb_inplace(
+    path: Path,
+    executor: DatabricksExecutor,
+    timeout: timedelta | None = None,
+) -> ExecutionResult:
     """Execute notebook cells and write outputs back into the notebook file.
 
     Saves a backup at <path>.bak before mutating; restores on exception.
@@ -100,6 +119,7 @@ def _run_ipynb_inplace(path: Path, executor: DatabricksExecutor) -> ExecutionRes
     Args:
         path: Path to the .ipynb notebook to execute in-place.
         executor: Initialized DatabricksExecutor with an active context.
+        timeout: Execution timeout per cell (default: COMMAND_EXECUTION_TIMEOUT).
 
     Returns:
         Summary ExecutionResult with combined output from all cells.
@@ -124,7 +144,7 @@ def _run_ipynb_inplace(path: Path, executor: DatabricksExecutor) -> ExecutionRes
             if not source.strip():
                 continue
 
-            result = executor.execute(source)
+            result = executor.execute(source, timeout=timeout)
             last_result = result
 
             cell_outputs: list[dict[str, Any]] = []
@@ -220,11 +240,22 @@ def _cli_dispatch(subcommand: str) -> None:
     from .executor import DatabricksExecutor
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("file")
-    parser.add_argument("--output-dir", default=".cache/outputs")
+    parser.add_argument("file", help="path to the file to execute")
+    parser.add_argument(
+        "--output-dir",
+        default=".cache/outputs",
+        help="directory to write output file into (default: .cache/outputs)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="execution timeout in seconds (default: 600)",
+    )
     parsed = parser.parse_args()
     file_path = Path(parsed.file)
     output_dir = parsed.output_dir
+    timeout = timedelta(seconds=parsed.timeout)
 
     config = Config.load()
     executor = DatabricksExecutor(config)
@@ -233,7 +264,7 @@ def _cli_dispatch(subcommand: str) -> None:
         fn = {"run_py": run_py, "run_db_py": run_db_py, "run_ipynb": run_ipynb}[
             subcommand
         ]
-        result = fn(file_path, executor)
+        result = fn(file_path, executor, timeout=timeout)
         write_output(result, file_path, output_dir)
     finally:
         executor.destroy_context()
@@ -288,13 +319,28 @@ def cli_run_ipynb() -> None:
     from .executor import DatabricksExecutor, ExecutionResult
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("file")
-    parser.add_argument("--inplace", action="store_true")
-    parser.add_argument("--output-dir", default=".cache/outputs")
+    parser.add_argument("file", help="path to the .ipynb file to execute")
+    parser.add_argument(
+        "--inplace",
+        action="store_true",
+        help="write cell outputs back into the notebook (backup at <path>.bak)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=".cache/outputs",
+        help="directory to write output file into (default: .cache/outputs)",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="execution timeout per cell in seconds (default: 600)",
+    )
     parsed = parser.parse_args()
     file_path = Path(parsed.file)
     inplace = parsed.inplace
     output_dir = parsed.output_dir
+    timeout = timedelta(seconds=parsed.timeout)
 
     config = Config.load()
     executor = DatabricksExecutor(config)
@@ -302,11 +348,11 @@ def cli_run_ipynb() -> None:
     try:
         if inplace:
             try:
-                result = _run_ipynb_inplace(file_path, executor)
+                result = _run_ipynb_inplace(file_path, executor, timeout=timeout)
             except Exception as e:
                 result = ExecutionResult(status="error", error=str(e))
         else:
-            result = run_ipynb(file_path, executor)
+            result = run_ipynb(file_path, executor, timeout=timeout)
         write_output(result, file_path, output_dir)
     finally:
         executor.destroy_context()

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -209,7 +209,7 @@ def write_output(
     outputs_dir = Path(output_dir)
     outputs_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now().strftime("%Y%m%dT%H%M%S")
-    out_path = outputs_dir / f"{path.stem}.{timestamp}.output.md"
+    out_path = outputs_dir / f"{path.name}.{timestamp}.output.md"
 
     lines: list[str] = [
         f"# Output: {path.name}",

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -230,12 +230,24 @@ def _cli_dispatch(subcommand: str) -> None:
 
 
 def cli_run_py() -> None:
-    """CLI entry point for run-py."""
+    """CLI entry point for run-py.
+
+    Executes a .py file on the cluster. Output is written to
+    outputs/<stem>.output.md relative to CWD. Default execution timeout is
+    10 minutes; the cluster command is cancelled on timeout. Exits with
+    code 1 on error or timeout.
+    """
     _cli_dispatch("run_py")
 
 
 def cli_run_db_py() -> None:
-    """CLI entry point for run-db-py."""
+    """CLI entry point for run-db-py.
+
+    Executes a Databricks .py notebook on the cluster. Output is written to
+    outputs/<stem>.output.md relative to CWD. Default execution timeout is
+    10 minutes; the cluster command is cancelled on timeout. Exits with
+    code 1 on error or timeout.
+    """
     _cli_dispatch("run_db_py")
 
 
@@ -244,8 +256,13 @@ def cli_run_ipynb() -> None:
 
     Usage: run-ipynb <path> [--inplace]
 
-    Without --inplace: executes cells and writes output to outputs/<stem>.output.md.
-    With --inplace: writes cell outputs back into the notebook (backup at <path>.bak).
+    Without --inplace: executes cells and writes combined output to
+    outputs/<stem>.output.md relative to CWD.
+    With --inplace: writes cell outputs back into the notebook (backup at
+    <path>.bak).
+
+    Default execution timeout per cell is 10 minutes; the cluster command is
+    cancelled on timeout. Exits with code 1 on error or timeout.
     """
     import sys
 

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -225,6 +225,8 @@ def _cli_dispatch(subcommand: str) -> None:
         write_output(result, file_path)
     finally:
         executor.destroy_context()
+    if result.status == "error":
+        sys.exit(1)
 
 
 def cli_run_py() -> None:
@@ -248,7 +250,7 @@ def cli_run_ipynb() -> None:
     import sys
 
     from .config import Config
-    from .executor import DatabricksExecutor
+    from .executor import DatabricksExecutor, ExecutionResult
 
     args = sys.argv[1:]
     inplace = "--inplace" in args
@@ -260,12 +262,17 @@ def cli_run_ipynb() -> None:
     executor.create_context()
     try:
         if inplace:
-            result = _run_ipynb_inplace(file_path, executor)
+            try:
+                result = _run_ipynb_inplace(file_path, executor)
+            except Exception as e:
+                result = ExecutionResult(status="error", error=str(e))
         else:
             result = run_ipynb(file_path, executor)
         write_output(result, file_path)
     finally:
         executor.destroy_context()
+    if result.status == "error":
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -43,13 +43,61 @@ def run_db_py(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
 
 
 def run_ipynb(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
-    """Execute all code cells of a notebook, writing outputs back in-place.
+    """Execute all code cells of a notebook and return combined output.
 
-    Saves a backup at <path>.bak before mutating; restores on exception.
-    Returns a summary ExecutionResult combining all cell outputs.
+    Does NOT modify the notebook file. Use cli_run_ipynb with --inplace to
+    write cell outputs back to the notebook.
 
     Args:
         path: Path to the .ipynb notebook to execute.
+        executor: Initialized DatabricksExecutor with an active context.
+
+    Returns:
+        Summary ExecutionResult with combined output from all cells.
+    """
+    with open(path, encoding="utf-8") as f:
+        notebook: dict[str, Any] = json.load(f)
+
+    cells = notebook.get("cells", [])
+    combined_output: list[str] = []
+    last_result = None
+
+    for cell in cells:
+        if cell.get("cell_type") != "code":
+            continue
+        source = cell.get("source", "")
+        if isinstance(source, list):
+            source = "".join(source)
+        if not source.strip():
+            continue
+
+        result = executor.execute(source)
+        last_result = result
+
+        if result.output:
+            combined_output.append(result.output)
+        if result.error:
+            combined_output.append(f"ERROR: {result.error}")
+
+    from .executor import ExecutionResult
+
+    if last_result is None:
+        return ExecutionResult(status="ok", output="(no code cells)")
+
+    return ExecutionResult(
+        status=last_result.status,
+        output="\n".join(combined_output) if combined_output else None,
+        error=last_result.error,
+    )
+
+
+def _run_ipynb_inplace(path: Path, executor: DatabricksExecutor) -> ExecutionResult:
+    """Execute notebook cells and write outputs back into the notebook file.
+
+    Saves a backup at <path>.bak before mutating; restores on exception.
+
+    Args:
+        path: Path to the .ipynb notebook to execute in-place.
         executor: Initialized DatabricksExecutor with an active context.
 
     Returns:
@@ -190,8 +238,34 @@ def cli_run_db_py() -> None:
 
 
 def cli_run_ipynb() -> None:
-    """CLI entry point for run-ipynb."""
-    _cli_dispatch("run_ipynb")
+    """CLI entry point for run-ipynb.
+
+    Usage: run-ipynb <path> [--inplace]
+
+    Without --inplace: executes cells and writes output to outputs/<stem>.output.md.
+    With --inplace: writes cell outputs back into the notebook (backup at <path>.bak).
+    """
+    import sys
+
+    from .config import Config
+    from .executor import DatabricksExecutor
+
+    args = sys.argv[1:]
+    inplace = "--inplace" in args
+    file_args = [a for a in args if not a.startswith("--")]
+    file_path = Path(file_args[0])
+
+    config = Config.load()
+    executor = DatabricksExecutor(config)
+    executor.create_context()
+    try:
+        if inplace:
+            result = _run_ipynb_inplace(file_path, executor)
+        else:
+            result = run_ipynb(file_path, executor)
+        write_output(result, file_path)
+    finally:
+        executor.destroy_context()
 
 
 if __name__ == "__main__":

--- a/tests/fixtures/hello.py
+++ b/tests/fixtures/hello.py
@@ -1,0 +1,1 @@
+print("hello from runner")

--- a/tests/fixtures/sample.ipynb
+++ b/tests/fixtures/sample.ipynb
@@ -1,0 +1,30 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Databricks",
+   "language": "python",
+   "name": "databricks"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["print(\"cell 1\")"]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": ["print(\"cell 2\")"]
+  }
+ ]
+}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -527,3 +527,155 @@ class TestConfigBasePath:
 
         config = Config.load(config_path=custom_config)
         assert config.base_path == custom_dir
+
+
+class TestMcpProfile:
+    """Tests for mcp_profile loading (M1)."""
+
+    def test_default_mcp_profile_is_none(self) -> None:
+        """Test that mcp_profile defaults to None."""
+        config = Config()
+        assert config.mcp_profile is None
+
+    def test_load_mcp_profile_from_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test loading mcp_profile from DATABRICKS_MCP_PROFILE env var."""
+        monkeypatch.setenv("DATABRICKS_MCP_PROFILE", "my-profile")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)
+
+        config = Config.load()
+        assert config.mcp_profile == "my-profile"
+
+    def test_load_mcp_profile_from_databrickscfg(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test loading mcp_profile from ~/.databrickscfg."""
+        databrickscfg = tmp_path / ".databrickscfg"
+        databrickscfg.write_text("""
+[DEFAULT]
+cluster_id = cfg-cluster-123
+mcp_profile = cfg-profile
+""")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_MCP_PROFILE", raising=False)
+        monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+        config = Config.load()
+        assert config.mcp_profile == "cfg-profile"
+
+    def test_env_overrides_databrickscfg_mcp_profile(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test env var takes priority over databrickscfg for mcp_profile."""
+        databrickscfg = tmp_path / ".databrickscfg"
+        databrickscfg.write_text("""
+[DEFAULT]
+mcp_profile = cfg-profile
+""")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DATABRICKS_MCP_PROFILE", "env-profile")
+        monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)
+
+        config = Config.load()
+        assert config.mcp_profile == "env-profile"
+
+
+class TestDatabricksConfigJson:
+    """Tests for .databricks/config.json loader (M2)."""
+
+    def test_load_from_databricks_config_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test loading cluster_id and mcp_profile from .databricks/config.json."""
+        config_dir = tmp_path / ".databricks"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            '{"mcp_profile": "json-profile", "cluster_id": "json-cluster"}'
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_MCP_PROFILE", raising=False)
+
+        config = Config.load()
+        assert config.cluster_id == "json-cluster"
+        assert config.mcp_profile == "json-profile"
+
+    def test_workspace_url_raises_value_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that workspace_url in config.json raises ValueError."""
+        config_dir = tmp_path / ".databricks"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            '{"workspace_url": "https://example.databricks.com", "cluster_id": "x"}'
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_MCP_PROFILE", raising=False)
+
+        with pytest.raises(ValueError, match="workspace_url"):
+            Config.load()
+
+    def test_env_overrides_config_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test env var takes priority over .databricks/config.json."""
+        config_dir = tmp_path / ".databricks"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            '{"cluster_id": "json-cluster", "mcp_profile": "json-profile"}'
+        )
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DATABRICKS_CLUSTER_ID", "env-cluster")
+        monkeypatch.setenv("DATABRICKS_MCP_PROFILE", "env-profile")
+
+        config = Config.load()
+        assert config.cluster_id == "env-cluster"
+        assert config.mcp_profile == "env-profile"
+
+    def test_databrickscfg_overrides_config_json(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test ~/.databrickscfg takes priority over .databricks/config.json."""
+        config_dir = tmp_path / ".databricks"
+        config_dir.mkdir()
+        (config_dir / "config.json").write_text(
+            '{"cluster_id": "json-cluster", "mcp_profile": "json-profile"}'
+        )
+        databrickscfg = tmp_path / ".databrickscfg"
+        databrickscfg.write_text("""
+[DEFAULT]
+cluster_id = cfg-cluster
+mcp_profile = cfg-profile
+""")
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_MCP_PROFILE", raising=False)
+        monkeypatch.delenv("DATABRICKS_CONFIG_PROFILE", raising=False)
+
+        config = Config.load()
+        assert config.cluster_id == "cfg-cluster"
+        assert config.mcp_profile == "cfg-profile"
+
+    def test_config_json_not_found_is_noop(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test that missing .databricks/config.json is silently ignored."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.delenv("DATABRICKS_CLUSTER_ID", raising=False)
+        monkeypatch.delenv("DATABRICKS_MCP_PROFILE", raising=False)
+
+        config = Config.load()
+        assert config.cluster_id is None
+        assert config.mcp_profile is None

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,8 +7,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
-import pytest
-
 from jupyter_databricks_kernel.executor import ExecutionResult
 from jupyter_databricks_kernel.runner import run_db_py, run_ipynb, run_py, write_output
 
@@ -131,18 +129,6 @@ class TestRunIpynb:
 
         assert executor.execute.call_count == 2
 
-    def test_writes_outputs_back_in_place(self, tmp_path: Path) -> None:
-        """run_ipynb mutates the notebook file with cell outputs."""
-        nb = self._minimal_notebook(["print('hello')"])
-        nb_path = tmp_path / "test.ipynb"
-        nb_path.write_text(json.dumps(nb))
-        executor = _make_executor(output="hello")
-
-        run_ipynb(nb_path, executor)
-
-        updated = json.loads(nb_path.read_text())
-        assert updated["cells"][0]["outputs"] != []
-
     def test_returns_summary_execution_result(self, tmp_path: Path) -> None:
         """run_ipynb returns a summary ExecutionResult."""
         nb = self._minimal_notebook(["print('c1')", "print('c2')"])
@@ -180,33 +166,6 @@ class TestRunIpynb:
 
         run_ipynb(nb_path, executor)
         assert executor.execute.call_count == 1
-
-    def test_restores_backup_on_exception(self, tmp_path: Path) -> None:
-        """run_ipynb restores the original notebook if execution raises."""
-        nb = self._minimal_notebook(["print('original')"])
-        nb_path = tmp_path / "test.ipynb"
-        original_text = json.dumps(nb)
-        nb_path.write_text(original_text)
-
-        executor = MagicMock()
-        executor.execute.side_effect = RuntimeError("cluster error")
-
-        with pytest.raises(RuntimeError, match="cluster error"):
-            run_ipynb(nb_path, executor)
-
-        assert nb_path.read_text() == original_text
-        assert not nb_path.with_suffix(".ipynb.bak").exists()
-
-    def test_no_backup_file_left_on_success(self, tmp_path: Path) -> None:
-        """run_ipynb removes the backup after successful execution."""
-        nb = self._minimal_notebook(["print('ok')"])
-        nb_path = tmp_path / "test.ipynb"
-        nb_path.write_text(json.dumps(nb))
-        executor = _make_executor(output="ok")
-
-        run_ipynb(nb_path, executor)
-
-        assert not nb_path.with_suffix(".ipynb.bak").exists()
 
     def test_empty_notebook_returns_no_code_cells(self, tmp_path: Path) -> None:
         """run_ipynb on a notebook with no code cells returns a no-op result."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -45,7 +45,7 @@ class TestRunPy:
 
         result = run_py(py_file, executor)
 
-        executor.execute.assert_called_once_with("x = 1\n")
+        executor.execute.assert_called_once_with("x = 1\n", timeout=None)
         assert result.status == "ok"
 
     def test_returns_execution_result(self, tmp_path: Path) -> None:
@@ -74,7 +74,9 @@ class TestRunDbPy:
 
         result = run_db_py(py_file, executor)
 
-        executor.execute.assert_called_once_with("# Databricks notebook\nprint('db')\n")
+        executor.execute.assert_called_once_with(
+            "# Databricks notebook\nprint('db')\n", timeout=None
+        )
         assert result.status == "ok"
 
     def test_identical_behavior_to_run_py(self, tmp_path: Path) -> None:
@@ -200,7 +202,7 @@ class TestWriteOutput:
     """Tests for write_output()."""
 
     def test_creates_outputs_dir_and_file(self, tmp_path: Path) -> None:
-        """write_output creates outputs/<stem>.output.md relative to CWD."""
+        """write_output creates .cache/outputs/<stem>.<timestamp>.output.md."""
         import os
 
         os.chdir(tmp_path)
@@ -209,7 +211,9 @@ class TestWriteOutput:
 
         out_path = write_output(result, source)
 
-        assert out_path.resolve() == tmp_path / "outputs" / "script.output.md"
+        assert out_path.parent.resolve() == (tmp_path / ".cache" / "outputs").resolve()
+        assert out_path.name.startswith("script.")
+        assert out_path.name.endswith(".output.md")
         assert out_path.exists()
 
     def test_markdown_contains_status_and_output(self, tmp_path: Path) -> None:
@@ -262,4 +266,5 @@ class TestWriteOutput:
         source = tmp_path / "myfile.py"
 
         out_path = write_output(result, source)
-        assert out_path.name == "myfile.output.md"
+        assert out_path.name.startswith("myfile.")
+        assert out_path.name.endswith(".output.md")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,306 @@
+"""Tests for runner.py (M3)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from jupyter_databricks_kernel.executor import ExecutionResult
+from jupyter_databricks_kernel.runner import run_db_py, run_ipynb, run_py, write_output
+
+if TYPE_CHECKING:
+    from jupyter_databricks_kernel.executor import DatabricksExecutor
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_executor(output: str = "ok-output", error: str | None = None) -> MagicMock:
+    """Return a minimal mock executor whose execute() returns a fixed result."""
+    executor = MagicMock()
+    status = "error" if error else "ok"
+    executor.execute.return_value = ExecutionResult(
+        status=status, output=output, error=error
+    )
+    return executor
+
+
+# ---------------------------------------------------------------------------
+# run_py
+# ---------------------------------------------------------------------------
+
+
+class TestRunPy:
+    """Tests for run_py()."""
+
+    def test_reads_file_and_executes(self, tmp_path: Path) -> None:
+        """run_py reads the file and passes its content to executor.execute."""
+        py_file = tmp_path / "script.py"
+        py_file.write_text("x = 1\n")
+        executor = _make_executor()
+
+        result = run_py(py_file, executor)
+
+        executor.execute.assert_called_once_with("x = 1\n")
+        assert result.status == "ok"
+
+    def test_returns_execution_result(self, tmp_path: Path) -> None:
+        """run_py returns the ExecutionResult from the executor."""
+        py_file = tmp_path / "hello.py"
+        py_file.write_text("print('hi')\n")
+        executor = _make_executor(output="hi")
+
+        result = run_py(py_file, executor)
+        assert result.output == "hi"
+
+
+# ---------------------------------------------------------------------------
+# run_db_py
+# ---------------------------------------------------------------------------
+
+
+class TestRunDbPy:
+    """Tests for run_db_py()."""
+
+    def test_reads_file_and_executes(self, tmp_path: Path) -> None:
+        """run_db_py reads the file and passes its content to executor.execute."""
+        py_file = tmp_path / "notebook.py"
+        py_file.write_text("# Databricks notebook\nprint('db')\n")
+        executor = _make_executor()
+
+        result = run_db_py(py_file, executor)
+
+        executor.execute.assert_called_once_with("# Databricks notebook\nprint('db')\n")
+        assert result.status == "ok"
+
+    def test_identical_behavior_to_run_py(self, tmp_path: Path) -> None:
+        """run_db_py and run_py produce the same result for the same file."""
+        py_file = tmp_path / "both.py"
+        py_file.write_text("print('same')\n")
+
+        executor_a = _make_executor(output="same")
+        executor_b = _make_executor(output="same")
+
+        result_py = run_py(py_file, executor_a)
+        result_db = run_db_py(py_file, executor_b)
+
+        assert result_py.status == result_db.status
+        assert result_py.output == result_db.output
+
+
+# ---------------------------------------------------------------------------
+# run_ipynb
+# ---------------------------------------------------------------------------
+
+
+class TestRunIpynb:
+    """Tests for run_ipynb()."""
+
+    def _minimal_notebook(self, cells: list[str]) -> dict:
+        """Build a minimal nbformat 4 notebook dict."""
+        return {
+            "nbformat": 4,
+            "nbformat_minor": 5,
+            "metadata": {},
+            "cells": [
+                {
+                    "cell_type": "code",
+                    "execution_count": None,
+                    "metadata": {},
+                    "outputs": [],
+                    "source": [src],
+                }
+                for src in cells
+            ],
+        }
+
+    def test_executes_all_code_cells(self, tmp_path: Path) -> None:
+        """run_ipynb calls executor.execute for each code cell."""
+        nb = self._minimal_notebook(["print('a')", "print('b')"])
+        nb_path = tmp_path / "test.ipynb"
+        nb_path.write_text(json.dumps(nb))
+        executor = _make_executor(output="x")
+
+        run_ipynb(nb_path, executor)
+
+        assert executor.execute.call_count == 2
+
+    def test_writes_outputs_back_in_place(self, tmp_path: Path) -> None:
+        """run_ipynb mutates the notebook file with cell outputs."""
+        nb = self._minimal_notebook(["print('hello')"])
+        nb_path = tmp_path / "test.ipynb"
+        nb_path.write_text(json.dumps(nb))
+        executor = _make_executor(output="hello")
+
+        run_ipynb(nb_path, executor)
+
+        updated = json.loads(nb_path.read_text())
+        assert updated["cells"][0]["outputs"] != []
+
+    def test_returns_summary_execution_result(self, tmp_path: Path) -> None:
+        """run_ipynb returns a summary ExecutionResult."""
+        nb = self._minimal_notebook(["print('c1')", "print('c2')"])
+        nb_path = tmp_path / "test.ipynb"
+        nb_path.write_text(json.dumps(nb))
+        executor = _make_executor(output="out")
+
+        result = run_ipynb(nb_path, executor)
+        assert result.status == "ok"
+
+    def test_skips_non_code_cells(self, tmp_path: Path) -> None:
+        """run_ipynb skips markdown cells."""
+        nb = {
+            "nbformat": 4,
+            "nbformat_minor": 5,
+            "metadata": {},
+            "cells": [
+                {
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": ["# header"],
+                },
+                {
+                    "cell_type": "code",
+                    "execution_count": None,
+                    "metadata": {},
+                    "outputs": [],
+                    "source": ["print('code')"],
+                },
+            ],
+        }
+        nb_path = tmp_path / "test.ipynb"
+        nb_path.write_text(json.dumps(nb))
+        executor = _make_executor(output="code")
+
+        run_ipynb(nb_path, executor)
+        assert executor.execute.call_count == 1
+
+    def test_restores_backup_on_exception(self, tmp_path: Path) -> None:
+        """run_ipynb restores the original notebook if execution raises."""
+        nb = self._minimal_notebook(["print('original')"])
+        nb_path = tmp_path / "test.ipynb"
+        original_text = json.dumps(nb)
+        nb_path.write_text(original_text)
+
+        executor = MagicMock()
+        executor.execute.side_effect = RuntimeError("cluster error")
+
+        with pytest.raises(RuntimeError, match="cluster error"):
+            run_ipynb(nb_path, executor)
+
+        assert nb_path.read_text() == original_text
+        assert not nb_path.with_suffix(".ipynb.bak").exists()
+
+    def test_no_backup_file_left_on_success(self, tmp_path: Path) -> None:
+        """run_ipynb removes the backup after successful execution."""
+        nb = self._minimal_notebook(["print('ok')"])
+        nb_path = tmp_path / "test.ipynb"
+        nb_path.write_text(json.dumps(nb))
+        executor = _make_executor(output="ok")
+
+        run_ipynb(nb_path, executor)
+
+        assert not nb_path.with_suffix(".ipynb.bak").exists()
+
+    def test_empty_notebook_returns_no_code_cells(self, tmp_path: Path) -> None:
+        """run_ipynb on a notebook with no code cells returns a no-op result."""
+        nb = {
+            "nbformat": 4,
+            "nbformat_minor": 5,
+            "metadata": {},
+            "cells": [
+                {
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": ["# only markdown"],
+                }
+            ],
+        }
+        nb_path = tmp_path / "empty.ipynb"
+        nb_path.write_text(json.dumps(nb))
+        executor = _make_executor()
+
+        result = run_ipynb(nb_path, executor)
+        executor.execute.assert_not_called()
+        assert result.status == "ok"
+        assert result.output == "(no code cells)"
+
+
+# ---------------------------------------------------------------------------
+# write_output
+# ---------------------------------------------------------------------------
+
+
+class TestWriteOutput:
+    """Tests for write_output()."""
+
+    def test_creates_outputs_dir_and_file(self, tmp_path: Path) -> None:
+        """write_output creates outputs/<stem>.output.md relative to CWD."""
+        import os
+
+        os.chdir(tmp_path)
+        result = ExecutionResult(status="ok", output="hello")
+        source = tmp_path / "script.py"
+
+        out_path = write_output(result, source)
+
+        assert out_path.resolve() == tmp_path / "outputs" / "script.output.md"
+        assert out_path.exists()
+
+    def test_markdown_contains_status_and_output(self, tmp_path: Path) -> None:
+        """write_output writes status and output sections."""
+        import os
+
+        os.chdir(tmp_path)
+        result = ExecutionResult(status="ok", output="42")
+        source = tmp_path / "calc.py"
+
+        out_path = write_output(result, source)
+        text = out_path.read_text()
+
+        assert "**Status:** ok" in text
+        assert "42" in text
+
+    def test_error_section_present_when_error(self, tmp_path: Path) -> None:
+        """write_output includes an Error section when result.error is set."""
+        import os
+
+        os.chdir(tmp_path)
+        result = ExecutionResult(status="error", error="NameError: x")
+        source = tmp_path / "bad.py"
+
+        out_path = write_output(result, source)
+        text = out_path.read_text()
+
+        assert "## Error" in text
+        assert "NameError: x" in text
+
+    def test_no_error_section_when_no_error(self, tmp_path: Path) -> None:
+        """write_output omits Error section when result.error is None."""
+        import os
+
+        os.chdir(tmp_path)
+        result = ExecutionResult(status="ok", output="fine")
+        source = tmp_path / "good.py"
+
+        out_path = write_output(result, source)
+        text = out_path.read_text()
+
+        assert "## Error" not in text
+
+    def test_returns_output_path(self, tmp_path: Path) -> None:
+        """write_output returns the path to the written file."""
+        import os
+
+        os.chdir(tmp_path)
+        result = ExecutionResult(status="ok")
+        source = tmp_path / "myfile.py"
+
+        out_path = write_output(result, source)
+        assert out_path.name == "myfile.output.md"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -13,7 +13,7 @@ from jupyter_databricks_kernel.executor import ExecutionResult
 from jupyter_databricks_kernel.runner import run_db_py, run_ipynb, run_py, write_output
 
 if TYPE_CHECKING:
-    from jupyter_databricks_kernel.executor import DatabricksExecutor
+    pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -212,7 +212,7 @@ class TestWriteOutput:
         out_path = write_output(result, source)
 
         assert out_path.parent.resolve() == (tmp_path / ".cache" / "outputs").resolve()
-        assert out_path.name.startswith("script.")
+        assert out_path.name.startswith("script.py.")
         assert out_path.name.endswith(".output.md")
         assert out_path.exists()
 
@@ -266,5 +266,5 @@ class TestWriteOutput:
         source = tmp_path / "myfile.py"
 
         out_path = write_output(result, source)
-        assert out_path.name.startswith("myfile.")
+        assert out_path.name.startswith("myfile.py.")
         assert out_path.name.endswith(".output.md")


### PR DESCRIPTION
## Summary

Implements the runner CLI and MCP config loader for issue #223.

All three commands verified end-to-end on DEFAULT Databricks workspace (cluster 0425-163924-e1rfmuqc, Spark 4.0.0).

## Changes

### Runner CLI (`src/jupyter_databricks_kernel/runner.py`)

Three new entry-point commands: `run-py`, `run-db-py`, `run-ipynb`.

| Feature | Details |
|---|---|
| Commands | `run-py <file.py>`, `run-db-py <file.py>`, `run-ipynb <file.ipynb>` |
| Flags | `--output-dir DIR` (default: `.cache/outputs/`), `--timeout INT` (default: 600), `--inplace` (run-ipynb only) |
| Execution | Synchronous — blocks until cluster finishes or times out |
| Output | Written to `<output-dir>/<filename>.<YYYYMMDDTHHMMSS>.output.md` |
| Exit code | `0` on success, `1` on error or timeout |
| Timeout | 600 s (10 min) per command / per cell; configurable via `--timeout` |
| Timeout handling | Cluster command cancelled via API before raising; error written to output file |
| `--inplace` | Backs up `.ipynb`, writes execution results back in-place |
| Databricks format | `run-db-py` accepts `# Databricks notebook source` / `# COMMAND ----------` format; pure-Python cells execute correctly |
| PySpark | Spark context available on cluster; PySpark scripts execute successfully |
| Rich output | Text stdout only; `images` / `table_data` captured by executor but not serialized to output file (known gap, future work) |

### Config loader (`src/jupyter_databricks_kernel/config.py`)

- Loads MCP profile from `config.json` alongside existing cluster/sync config
- Log format string wrapped to stay within 88-char ruff limit

### Documentation (`README.md`)

- Section 5.3: added Runner CLI behaviour notes (timeout, cancel, exit code, `--inplace`)

## Verified Behaviors

All three commands tested on DEFAULT workspace (cluster 0425-163924-e1rfmuqc, Spark 4.0.0, 2026-04-27):

| Command | Test | Result |
|---|---|---|
| `run-py` | `print(1+1)` | ✓ output: `2` |
| `run-db-py` | 3-cell Databricks format notebook (pure Python) | ✓ all 3 cells executed |
| `run-db-py` | PySpark: `SparkSession + createDataFrame + show()` | ✓ Spark 4.0.0 |
| `run-ipynb` | 1-cell notebook: `print(42)` | ✓ output: `42` |

## Closes

Closes #223
