### PR TITLE
fix(sync): reject Workspace extraction paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,19 +142,23 @@ max_file_size_mb = 10.0
 use_gitignore = true
 ```
 
-| Option                          | Description                            | Default       |
-| ------------------------------- | -------------------------------------- | ------------- |
-| `sync.enabled`                  | Enable file synchronization            | `true`        |
-| `sync.source`                   | Source directory to sync               | `"."`         |
-| `sync.exclude`                  | Additional exclude patterns            | `[]`          |
-| `sync.max_size_mb`              | Maximum total project size in MB       | No limit      |
-| `sync.max_file_size_mb`         | Maximum individual file size in MB     | No limit      |
-| `sync.use_gitignore`            | Respect .gitignore patterns            | `true`        |
-| `sync.workspace_extract_dir`    | Custom extraction directory on cluster | `null` (auto) |
+| Option                       | Description                              | Default       |
+| ---------------------------- | ---------------------------------------- | ------------- |
+| `sync.enabled`               | Enable file synchronization              | `true`        |
+| `sync.source`                | Source directory to sync                 | `"."`         |
+| `sync.exclude`               | Additional exclude patterns              | `[]`          |
+| `sync.max_size_mb`           | Maximum total project size in MB         | No limit      |
+| `sync.max_file_size_mb`      | Maximum individual file size in MB       | No limit      |
+| `sync.use_gitignore`         | Respect .gitignore patterns              | `true`        |
+| `sync.workspace_extract_dir` | Custom driver-local extraction directory | `null` (auto) |
 
 The extraction directory can also be set via the
 `JUPYTER_DATABRICKS_KERNEL_EXTRACT_DIR` environment variable, which takes
 priority over `pyproject.toml`.
+
+Extraction runs on the cluster driver under `/tmp` by default. Legacy
+Databricks Workspace mount paths such as `/Workspace/...` are not used as a
+fallback and are rejected when configured explicitly.
 
 By default, files are extracted to
 `/tmp/jupyter_databricks_kernel/<project>-<hash>/` on the cluster driver node,

--- a/src/jupyter_databricks_kernel/config.py
+++ b/src/jupyter_databricks_kernel/config.py
@@ -13,6 +13,15 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 CANONICAL_PROJECT_CONFIG_PATH = Path(".databricks") / "jupyter-databricks-kernel.json"
+WORKSPACE_MOUNT_PREFIX = "/Workspace"
+
+
+def is_workspace_mount_path(path: str) -> bool:
+    """Return whether a remote path targets the Databricks Workspace mount."""
+    normalized = path.rstrip("/")
+    return normalized == WORKSPACE_MOUNT_PREFIX or normalized.startswith(
+        f"{WORKSPACE_MOUNT_PREFIX}/"
+    )
 
 
 @dataclass
@@ -275,5 +284,14 @@ class Config:
 
         if self.sync.max_file_size_mb is not None and self.sync.max_file_size_mb <= 0:
             errors.append("max_file_size_mb must be a positive number.")
+
+        if self.sync.workspace_extract_dir and is_workspace_mount_path(
+            self.sync.workspace_extract_dir
+        ):
+            errors.append(
+                "workspace_extract_dir must not use /Workspace. "
+                "Use the default /tmp/jupyter_databricks_kernel/"
+                "<project>-<hash>/ extraction path or another driver-local path."
+            )
 
         return errors

--- a/src/jupyter_databricks_kernel/sync.py
+++ b/src/jupyter_databricks_kernel/sync.py
@@ -26,8 +26,10 @@ from typing import TYPE_CHECKING, Any
 
 import pathspec
 from databricks.sdk import WorkspaceClient
+from pathspec.pattern import Pattern
 
 from . import __version__
+from .config import is_workspace_mount_path
 
 if TYPE_CHECKING:
     from .config import Config
@@ -483,7 +485,7 @@ class FileSync:
             raise ValueError(f"Invalid session_id format: {session_id}")
         self.session_id = session_id
         self._synced = False
-        self._pathspec: pathspec.PathSpec | None = None
+        self._pathspec: pathspec.PathSpec[Pattern] | None = None
         self._pathspec_mtime: float = 0.0
         self._file_cache: FileCache | None = None
         self._command_context_id: str | None = None
@@ -538,7 +540,7 @@ class FileSync:
         base = self.config.base_path if self.config.base_path else Path.cwd()
         return base / source
 
-    def _load_gitignore_spec(self, source_path: Path) -> pathspec.PathSpec:
+    def _load_gitignore_spec(self, source_path: Path) -> pathspec.PathSpec[Pattern]:
         """Load and cache the combined PathSpec from default and configured patterns.
 
         This method combines patterns from:
@@ -984,6 +986,12 @@ print(target_dir)
         # Check if custom workspace_extract_dir is configured
         if self.config.sync.workspace_extract_dir:
             workspace_extract_dir = self.config.sync.workspace_extract_dir
+            if is_workspace_mount_path(workspace_extract_dir):
+                raise ValueError(
+                    "workspace_extract_dir must not use /Workspace. "
+                    "Use the default /tmp/jupyter_databricks_kernel/"
+                    "<project>-<hash>/ extraction path or another driver-local path."
+                )
             # Use custom path directly without fallback
             return [
                 (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -216,6 +216,18 @@ class TestConfigValidate:
         errors = config.validate()
         assert len(errors) == 0
 
+    def test_validate_rejects_workspace_extract_dir_mount(self) -> None:
+        """Test validation rejects /Workspace extraction paths."""
+        config = Config(
+            cluster_id="test-cluster",
+            sync=SyncConfig(workspace_extract_dir="/Workspace/Users/example/project"),
+        )
+
+        errors = config.validate()
+
+        assert len(errors) == 1
+        assert "workspace_extract_dir must not use /Workspace" in errors[0]
+
     def test_validate_max_size_mb_positive(self) -> None:
         """Test validation fails when max_size_mb is not positive."""
         config = Config(cluster_id="test-cluster")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1178,6 +1178,17 @@ class TestGetSetupSteps:
         assert "_fallback_dir" not in prepare_code
         assert "try:" not in prepare_code
 
+    def test_workspace_mount_extract_dir_rejected(
+        self, mock_file_sync: FileSync
+    ) -> None:
+        """Test that /Workspace extraction paths are not supported."""
+        mock_file_sync.config.sync.workspace_extract_dir = (
+            "/Workspace/Users/example/project"
+        )
+
+        with pytest.raises(ValueError, match="must not use /Workspace"):
+            mock_file_sync.get_setup_steps("/tmp/test/project.zip")
+
     def test_default_path_is_deterministic(self, mock_file_sync: FileSync) -> None:
         """Test that default path is deterministic (no session UUID in path)."""
         cluster_zip_path = "/tmp/test/project.zip"


### PR DESCRIPTION
## Summary
- Reject `sync.workspace_extract_dir` values under `/Workspace`.
- Keep default extraction on driver-local `/tmp/jupyter_databricks_kernel/...`.
- Update README and tests for the removed Workspace fallback behavior.

## Verification
- `uv run ruff format --check src/jupyter_databricks_kernel/config.py src/jupyter_databricks_kernel/sync.py tests/test_config.py tests/test_sync.py`
- `uv run ruff check src/jupyter_databricks_kernel/config.py src/jupyter_databricks_kernel/sync.py tests/test_config.py tests/test_sync.py`
- `uv run mypy src`
- `uv run pytest -q tests/test_config.py tests/test_sync.py::TestGetSetupSteps`
- `nix run nixpkgs#rumdl -- check README.md`
- `git diff --check`

Closes #249
