### PR TITLE
feat(sync): skip unchanged file hashing with metadata cache (#126)

### DIFF
--- a/src/jupyter_databricks_kernel/sync.py
+++ b/src/jupyter_databricks_kernel/sync.py
@@ -170,6 +170,7 @@ class FileCache:
     _cache: dict[str, str] = field(default_factory=dict)
     _mtimes: dict[str, int] = field(default_factory=dict)
     _sizes: dict[str, int] = field(default_factory=dict)
+    _ctimes: dict[str, int] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Load cache from file after initialization."""
@@ -205,6 +206,7 @@ class FileCache:
                 self._cache = {}
                 self._mtimes = {}
                 self._sizes = {}
+                self._ctimes = {}
                 return
 
             self._cache = data.get("files", {})
@@ -218,11 +220,17 @@ class FileCache:
                 for path, size in data.get("sizes", {}).items()
                 if isinstance(path, str)
             }
+            self._ctimes = {
+                path: int(ctime)
+                for path, ctime in data.get("ctimes", {}).items()
+                if isinstance(path, str)
+            }
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Failed to load cache, resetting: %s", e)
             self._cache = {}
             self._mtimes = {}
             self._sizes = {}
+            self._ctimes = {}
 
     def save(self) -> None:
         """Save cache to file atomically.
@@ -246,6 +254,7 @@ class FileCache:
                 "files": self._cache,
                 "mtimes": self._mtimes,
                 "sizes": self._sizes,
+                "ctimes": self._ctimes,
             }
 
             # Create secure temporary file in same directory (for atomic rename)
@@ -337,6 +346,7 @@ class FileCache:
             self._cache.get(rel_path) is not None
             and self._mtimes.get(rel_path) == stat_result.st_mtime_ns
             and self._sizes.get(rel_path) == stat_result.st_size
+            and self._ctimes.get(rel_path) == stat_result.st_ctime_ns
         )
 
     def get_changed_files(
@@ -461,6 +471,7 @@ class FileCache:
                 if stat_result is not None:
                     self._mtimes[rel_path] = stat_result.st_mtime_ns
                     self._sizes[rel_path] = stat_result.st_size
+                    self._ctimes[rel_path] = stat_result.st_ctime_ns
             except OSError:
                 pass  # Skip files that can't be read
 
@@ -469,6 +480,7 @@ class FileCache:
         self._cache = {}
         self._mtimes = {}
         self._sizes = {}
+        self._ctimes = {}
 
     def get_deleted_files(self, current_files: list[Path]) -> list[str]:
         """Get list of files that exist in cache but not in current files.
@@ -497,6 +509,7 @@ class FileCache:
         self._cache.pop(rel_path, None)
         self._mtimes.pop(rel_path, None)
         self._sizes.pop(rel_path, None)
+        self._ctimes.pop(rel_path, None)
 
     def has_any_changed(self, files: list[Path]) -> bool:
         """Check if any file has changed, with early return on first change.
@@ -526,6 +539,7 @@ class FileCache:
                     return True
                 self._mtimes[rel_path] = stat_result.st_mtime_ns
                 self._sizes[rel_path] = stat_result.st_size
+                self._ctimes[rel_path] = stat_result.st_ctime_ns
             except OSError:
                 # File read error, treat as changed
                 return True

--- a/src/jupyter_databricks_kernel/sync.py
+++ b/src/jupyter_databricks_kernel/sync.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 SyncProgressCallback = Callable[[str], None]
 
 CACHE_FILE_NAME = ".jupyter-databricks-kernel-cache.json"
-CACHE_VERSION = 1
+CACHE_VERSION = 2
 
 # Default patterns that are always excluded, matching Databricks CLI behavior.
 # See: https://github.com/databricks/cli/blob/main/libs/git/view.go
@@ -168,6 +168,8 @@ class FileCache:
 
     source_path: Path
     _cache: dict[str, str] = field(default_factory=dict)
+    _mtimes: dict[str, int] = field(default_factory=dict)
+    _sizes: dict[str, int] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         """Load cache from file after initialization."""
@@ -201,12 +203,26 @@ class FileCache:
             if data.get("version") != CACHE_VERSION:
                 logger.warning("Cache version mismatch, resetting cache")
                 self._cache = {}
+                self._mtimes = {}
+                self._sizes = {}
                 return
 
             self._cache = data.get("files", {})
+            self._mtimes = {
+                path: int(mtime)
+                for path, mtime in data.get("mtimes", {}).items()
+                if isinstance(path, str)
+            }
+            self._sizes = {
+                path: int(size)
+                for path, size in data.get("sizes", {}).items()
+                if isinstance(path, str)
+            }
         except (json.JSONDecodeError, OSError) as e:
             logger.warning("Failed to load cache, resetting: %s", e)
             self._cache = {}
+            self._mtimes = {}
+            self._sizes = {}
 
     def save(self) -> None:
         """Save cache to file atomically.
@@ -228,6 +244,8 @@ class FileCache:
             data = {
                 "version": CACHE_VERSION,
                 "files": self._cache,
+                "mtimes": self._mtimes,
+                "sizes": self._sizes,
             }
 
             # Create secure temporary file in same directory (for atomic rename)
@@ -306,6 +324,21 @@ class FileCache:
         except OSError:
             return index, file_path, None, None
 
+    def _stat_file(self, file_path: Path) -> os.stat_result | None:
+        """Return file stat data, or None when the file cannot be read."""
+        try:
+            return file_path.stat()
+        except OSError:
+            return None
+
+    def _metadata_matches(self, rel_path: str, stat_result: os.stat_result) -> bool:
+        """Return whether cached mtime/size metadata matches current file state."""
+        return (
+            self._cache.get(rel_path) is not None
+            and self._mtimes.get(rel_path) == stat_result.st_mtime_ns
+            and self._sizes.get(rel_path) == stat_result.st_size
+        )
+
     def get_changed_files(
         self,
         files: list[Path],
@@ -333,43 +366,76 @@ class FileCache:
         hash_results: list[tuple[int, Path, str | None, str | None] | None] = [
             None
         ] * total
-        max_workers = self._hash_worker_count(total)
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = [
-                executor.submit(self._compute_file_hash, i, file_path)
-                for i, file_path in enumerate(files)
-            ]
-            for completed, future in enumerate(as_completed(futures), start=1):
-                if on_progress:
-                    on_progress(f"Hashing files... {completed}/{total}")
-                index, file_path, rel_path, current_hash = future.result()
-                hash_results[index] = (index, file_path, rel_path, current_hash)
+        files_to_hash: list[tuple[int, Path]] = []
+        for index, file_path in enumerate(files):
+            try:
+                rel_path = str(file_path.relative_to(self.source_path))
+            except ValueError:
+                hash_results[index] = (index, file_path, None, None)
+                continue
+
+            stat_result = self._stat_file(file_path)
+            if stat_result is None:
+                hash_results[index] = (index, file_path, None, None)
+                continue
+
+            if self._metadata_matches(rel_path, stat_result):
+                metadata_cached_hash = self._cache[rel_path]
+                computed_hashes[rel_path] = metadata_cached_hash
+                stats.skipped_files += 1
+            else:
+                files_to_hash.append((index, file_path))
+
+        if files_to_hash:
+            max_workers = self._hash_worker_count(len(files_to_hash))
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [
+                    executor.submit(self._compute_file_hash, i, file_path)
+                    for i, file_path in files_to_hash
+                ]
+                for completed, future in enumerate(as_completed(futures), start=1):
+                    if on_progress:
+                        on_progress(
+                            f"Hashing files... {completed}/{len(files_to_hash)}"
+                        )
+                    (
+                        result_index,
+                        result_file_path,
+                        result_rel_path,
+                        result_hash,
+                    ) = future.result()
+                    hash_results[result_index] = (
+                        result_index,
+                        result_file_path,
+                        result_rel_path,
+                        result_hash,
+                    )
 
         for result in hash_results:
             if result is None:
                 continue
-            _, file_path, rel_path, current_hash = result
+            _, result_file_path, result_rel_path, result_hash = result
 
-            if rel_path is not None and current_hash is not None:
-                computed_hashes[rel_path] = current_hash
-                cached_hash = self._cache.get(rel_path)
+            if result_rel_path is not None and result_hash is not None:
+                computed_hashes[result_rel_path] = result_hash
+                result_cached_hash = self._cache.get(result_rel_path)
 
-                if current_hash != cached_hash:
-                    changed.append(file_path)
+                if result_hash != result_cached_hash:
+                    changed.append(result_file_path)
                     stats.changed_files += 1
                     # Reuse pre-computed size if available
-                    if file_sizes and file_path in file_sizes:
-                        stats.changed_size += file_sizes[file_path]
+                    if file_sizes and result_file_path in file_sizes:
+                        stats.changed_size += file_sizes[result_file_path]
                     else:
                         try:
-                            stats.changed_size += file_path.stat().st_size
+                            stats.changed_size += result_file_path.stat().st_size
                         except OSError:
                             pass
                 else:
                     stats.skipped_files += 1
             else:
                 # File read error, treat as changed
-                changed.append(file_path)
+                changed.append(result_file_path)
                 stats.changed_files += 1
 
         return changed, stats, computed_hashes
@@ -391,12 +457,18 @@ class FileCache:
                     self._cache[rel_path] = computed_hashes[rel_path]
                 else:
                     self._cache[rel_path] = self.compute_hash(file_path)
+                stat_result = self._stat_file(file_path)
+                if stat_result is not None:
+                    self._mtimes[rel_path] = stat_result.st_mtime_ns
+                    self._sizes[rel_path] = stat_result.st_size
             except OSError:
                 pass  # Skip files that can't be read
 
     def clear(self) -> None:
         """Clear the cache."""
         self._cache = {}
+        self._mtimes = {}
+        self._sizes = {}
 
     def get_deleted_files(self, current_files: list[Path]) -> list[str]:
         """Get list of files that exist in cache but not in current files.
@@ -423,6 +495,8 @@ class FileCache:
             rel_path: Relative path of the file to remove.
         """
         self._cache.pop(rel_path, None)
+        self._mtimes.pop(rel_path, None)
+        self._sizes.pop(rel_path, None)
 
     def has_any_changed(self, files: list[Path]) -> bool:
         """Check if any file has changed, with early return on first change.
@@ -439,10 +513,19 @@ class FileCache:
         for file_path in files:
             try:
                 rel_path = str(file_path.relative_to(self.source_path))
+                stat_result = self._stat_file(file_path)
+                if stat_result is None:
+                    return True
+
+                if self._metadata_matches(rel_path, stat_result):
+                    continue
+
                 current_hash = self.compute_hash(file_path)
                 cached_hash = self._cache.get(rel_path)
                 if current_hash != cached_hash:
                     return True
+                self._mtimes[rel_path] = stat_result.st_mtime_ns
+                self._sizes[rel_path] = stat_result.st_size
             except OSError:
                 # File read error, treat as changed
                 return True

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -384,6 +384,47 @@ class TestFileCache:
             "Hashing files... 3/3",
         ]
 
+    def test_get_changed_files_skips_hash_when_metadata_matches(
+        self, tmp_path: Path
+    ) -> None:
+        """Test unchanged mtime/size metadata avoids unnecessary hashing."""
+        file1 = tmp_path / "file1.py"
+        file2 = tmp_path / "file2.py"
+        file1.write_text("content1")
+        file2.write_text("content2")
+
+        cache = FileCache(tmp_path)
+        cache.update([file1, file2])
+
+        with patch.object(FileCache, "compute_hash") as compute_hash:
+            changed, stats, computed_hashes = cache.get_changed_files([file1, file2])
+
+        compute_hash.assert_not_called()
+        assert changed == []
+        assert stats.changed_files == 0
+        assert stats.skipped_files == 2
+        assert set(computed_hashes) == {"file1.py", "file2.py"}
+
+    def test_get_changed_files_treats_deleted_file_as_changed_without_hashing(
+        self, tmp_path: Path
+    ) -> None:
+        """Test missing files remain changed when cached metadata short-circuits."""
+        file1 = tmp_path / "file1.py"
+        file1.write_text("content")
+
+        cache = FileCache(tmp_path)
+        cache.update([file1])
+        file1.unlink()
+
+        with patch.object(FileCache, "compute_hash") as compute_hash:
+            changed, stats, computed_hashes = cache.get_changed_files([file1])
+
+        compute_hash.assert_not_called()
+        assert changed == [file1]
+        assert stats.changed_files == 1
+        assert stats.skipped_files == 0
+        assert computed_hashes == {}
+
     def test_save_and_load_cache(self, tmp_path: Path) -> None:
         """Test cache persistence."""
         file1 = tmp_path / "file1.py"
@@ -511,6 +552,41 @@ class TestFileCache:
         cache.update([file1])
 
         assert cache.has_any_changed([file1]) is False
+
+    def test_has_any_changed_skips_hash_when_metadata_matches(
+        self, tmp_path: Path
+    ) -> None:
+        """Test mtime/size metadata provides a fast unchanged-file path."""
+        file1 = tmp_path / "file1.py"
+        file1.write_text("content")
+
+        cache = FileCache(tmp_path)
+        cache.update([file1])
+
+        with patch.object(FileCache, "compute_hash") as compute_hash:
+            assert cache.has_any_changed([file1]) is False
+
+        compute_hash.assert_not_called()
+
+    def test_has_any_changed_falls_back_to_hash_when_metadata_differs(
+        self, tmp_path: Path
+    ) -> None:
+        """Test mtime changes still fall back to hash comparison for accuracy."""
+        file1 = tmp_path / "file1.py"
+        file1.write_text("content")
+
+        cache = FileCache(tmp_path)
+        cache.update([file1])
+        old_mtime = cache._mtimes["file1.py"]
+        os.utime(file1, ns=(old_mtime + 1_000_000_000, old_mtime + 1_000_000_000))
+
+        with patch.object(
+            FileCache, "compute_hash", wraps=cache.compute_hash
+        ) as compute_hash:
+            assert cache.has_any_changed([file1]) is False
+
+        compute_hash.assert_called_once_with(file1)
+        assert cache._mtimes["file1.py"] == file1.stat().st_mtime_ns
 
     def test_has_any_changed_returns_true_for_new_file(self, tmp_path: Path) -> None:
         """Test that has_any_changed returns True for uncached files."""

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -6,6 +6,7 @@ import base64
 import json
 import os
 import re
+import time
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, Mock, patch
 
@@ -387,7 +388,7 @@ class TestFileCache:
     def test_get_changed_files_skips_hash_when_metadata_matches(
         self, tmp_path: Path
     ) -> None:
-        """Test unchanged mtime/size metadata avoids unnecessary hashing."""
+        """Test unchanged cached metadata avoids unnecessary hashing."""
         file1 = tmp_path / "file1.py"
         file2 = tmp_path / "file2.py"
         file1.write_text("content1")
@@ -404,6 +405,32 @@ class TestFileCache:
         assert stats.changed_files == 0
         assert stats.skipped_files == 2
         assert set(computed_hashes) == {"file1.py", "file2.py"}
+
+    def test_get_changed_files_detects_same_size_change_with_restored_mtime(
+        self, tmp_path: Path
+    ) -> None:
+        """Test ctime metadata preserves accuracy when mtime and size match."""
+        file1 = tmp_path / "file1.py"
+        file1.write_text("content1")
+
+        cache = FileCache(tmp_path)
+        cache.update([file1])
+        cached_mtime = file1.stat().st_mtime_ns
+
+        time.sleep(0.01)
+        file1.write_text("CONTENT1")
+        os.utime(file1, ns=(cached_mtime, cached_mtime))
+
+        with patch.object(
+            FileCache, "compute_hash", wraps=cache.compute_hash
+        ) as compute_hash:
+            changed, stats, computed_hashes = cache.get_changed_files([file1])
+
+        compute_hash.assert_called_once_with(file1)
+        assert changed == [file1]
+        assert stats.changed_files == 1
+        assert stats.skipped_files == 0
+        assert computed_hashes["file1.py"] != cache._cache["file1.py"]
 
     def test_get_changed_files_treats_deleted_file_as_changed_without_hashing(
         self, tmp_path: Path
@@ -556,7 +583,7 @@ class TestFileCache:
     def test_has_any_changed_skips_hash_when_metadata_matches(
         self, tmp_path: Path
     ) -> None:
-        """Test mtime/size metadata provides a fast unchanged-file path."""
+        """Test cached metadata provides a fast unchanged-file path."""
         file1 = tmp_path / "file1.py"
         file1.write_text("content")
 
@@ -567,6 +594,28 @@ class TestFileCache:
             assert cache.has_any_changed([file1]) is False
 
         compute_hash.assert_not_called()
+
+    def test_has_any_changed_detects_same_size_change_with_restored_mtime(
+        self, tmp_path: Path
+    ) -> None:
+        """Test ctime metadata prevents false unchanged results."""
+        file1 = tmp_path / "file1.py"
+        file1.write_text("content")
+
+        cache = FileCache(tmp_path)
+        cache.update([file1])
+        cached_mtime = file1.stat().st_mtime_ns
+
+        time.sleep(0.01)
+        file1.write_text("CONTENT")
+        os.utime(file1, ns=(cached_mtime, cached_mtime))
+
+        with patch.object(
+            FileCache, "compute_hash", wraps=cache.compute_hash
+        ) as compute_hash:
+            assert cache.has_any_changed([file1]) is True
+
+        compute_hash.assert_called_once_with(file1)
 
     def test_has_any_changed_falls_back_to_hash_when_metadata_differs(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

- Add a metadata cache to skip unchanged file hashing during sync.
- Keep hash fallback behavior for changed or untracked metadata states.
- Add focused sync tests for unchanged-file cache behavior.

## Verification

- Not run by worker-alt; PR created from already pushed branch.

Closes #126