### PR TITLE
feat(runner): add unified run CLI (#251)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,24 @@ If the cluster is stopped, kernel startup may take 5-6 minutes. Increase
 jupyter execute notebook.ipynb --kernel_name=databricks --startup_timeout=600
 ```
 
-### 5.3. Runner CLI (`run-py`, `run-db-py`, `run-ipynb`)
+### 5.3. Runner CLI (`run`)
 
 Execute scripts and notebooks directly without launching Jupyter:
+
+```bash
+uv run run path/to/script.py
+uv run run path/to/notebook.db.py
+uv run run path/to/notebook.ipynb
+```
+
+The unified `run` command dispatches by file extension. Use `--format` to
+override detection:
+
+```bash
+uv run run --format db-py path/to/notebook.py
+```
+
+The previous entry points remain available as compatibility aliases:
 
 ```bash
 uv run run-py path/to/script.py
@@ -220,7 +235,11 @@ uv run run-ipynb path/to/notebook.ipynb
 
 Output is written to `.cache/outputs/<stem>.<YYYYMMDDTHHMMSS>.output.md`
 relative to the current working directory. Use `--output-dir` to override the
-directory.
+directory. The `--serverless` flag is recognized but currently fails fast
+because the implemented runner backend uses the Databricks Command Execution
+API on classic all-purpose clusters. See
+[serverless execution backend investigation](./docs/serverless-execution-backend.md)
+for the required separate backend design.
 
 #### Behavior notes
 
@@ -232,6 +251,7 @@ directory.
 | Timeout handling | Cluster command is cancelled; error written to output file |
 | Exit code | Exits with code 1 on error or timeout; code 0 on success |
 | `run-ipynb --inplace` | Writes cell outputs back into the notebook; backup at `<path>.bak` |
+| `run --serverless` | Recognized, but exits with an unsupported-backend error |
 
 ## 6. Papermill Integration
 

--- a/README.md
+++ b/README.md
@@ -208,26 +208,27 @@ If the cluster is stopped, kernel startup may take 5-6 minutes. Increase
 jupyter execute notebook.ipynb --kernel_name=databricks --startup_timeout=600
 ```
 
-### 5.3. Runner CLI (`run`)
+### 5.3. Runner CLI (`databricks-run`)
 
 Execute scripts and notebooks directly without launching Jupyter:
 
 ```bash
-uv run run path/to/script.py
-uv run run path/to/notebook.db.py
-uv run run path/to/notebook.ipynb
+uv run databricks-run path/to/script.py
+uv run databricks-run path/to/notebook.db.py
+uv run databricks-run path/to/notebook.ipynb
 ```
 
-The unified `run` command dispatches by file extension. Use `--format` to
-override detection:
+The unified `databricks-run` command dispatches by file extension. Use
+`--format` to override detection:
 
 ```bash
-uv run run --format db-py path/to/notebook.py
+uv run databricks-run --format db-py path/to/notebook.py
 ```
 
 The previous entry points remain available as compatibility aliases:
 
 ```bash
+uv run run path/to/script.py
 uv run run-py path/to/script.py
 uv run run-db-py path/to/notebook.py
 uv run run-ipynb path/to/notebook.ipynb
@@ -251,7 +252,7 @@ for the required separate backend design.
 | Timeout handling | Cluster command is cancelled; error written to output file |
 | Exit code | Exits with code 1 on error or timeout; code 0 on success |
 | `run-ipynb --inplace` | Writes cell outputs back into the notebook; backup at `<path>.bak` |
-| `run --serverless` | Recognized, but exits with an unsupported-backend error |
+| `databricks-run --serverless` | Recognized, but exits with an unsupported-backend error |
 
 ## 6. Papermill Integration
 

--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ uv run run-ipynb path/to/notebook.ipynb
 Output is written to `.cache/outputs/<stem>.<YYYYMMDDTHHMMSS>.output.md`
 relative to the current working directory. Use `--output-dir` to override the
 directory. The `--serverless` flag is recognized but currently fails fast
-because the implemented runner backend uses the Databricks Command Execution
-API on classic all-purpose clusters. See
+because the implemented runner backend uses the Databricks Command Execution API
+on classic all-purpose clusters. See
 [serverless execution backend investigation](./docs/serverless-execution-backend.md)
 for the required separate backend design.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
 ]
 
 [project.scripts]
+run       = "jupyter_databricks_kernel.runner:cli_run"
 run-py    = "jupyter_databricks_kernel.runner:cli_run_py"
 run-db-py = "jupyter_databricks_kernel.runner:cli_run_db_py"
 run-ipynb = "jupyter_databricks_kernel.runner:cli_run_ipynb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,11 @@ dependencies = [
 ]
 
 [project.scripts]
-run       = "jupyter_databricks_kernel.runner:cli_run"
-run-py    = "jupyter_databricks_kernel.runner:cli_run_py"
-run-db-py = "jupyter_databricks_kernel.runner:cli_run_db_py"
-run-ipynb = "jupyter_databricks_kernel.runner:cli_run_ipynb"
+databricks-run = "jupyter_databricks_kernel.runner:cli_run"
+run            = "jupyter_databricks_kernel.runner:cli_run"
+run-py         = "jupyter_databricks_kernel.runner:cli_run_py"
+run-db-py      = "jupyter_databricks_kernel.runner:cli_run_db_py"
+run-ipynb      = "jupyter_databricks_kernel.runner:cli_run_ipynb"
 
 [dependency-groups]
 dev = [

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -368,7 +368,7 @@ def _cli_dispatch(default_format: RunFormat | None = None) -> None:
 
 
 def cli_run() -> None:
-    """Unified CLI entry point for Databricks runner execution."""
+    """Unified CLI entry point for databricks-run."""
     _cli_dispatch()
 
 

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -6,10 +6,75 @@ import json
 import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 if TYPE_CHECKING:
     from .executor import DatabricksExecutor, ExecutionResult
+
+RunFormat = Literal["py", "db-py", "ipynb"]
+
+
+def detect_run_format(
+    path: Path, explicit_format: RunFormat | None = None
+) -> RunFormat:
+    """Detect the runner format for a path.
+
+    Args:
+        path: File path to dispatch.
+        explicit_format: Optional user-selected format.
+
+    Returns:
+        The runner format.
+
+    Raises:
+        ValueError: If the file extension cannot be dispatched.
+    """
+    if explicit_format is not None:
+        return explicit_format
+    if path.suffix == ".ipynb":
+        return "ipynb"
+    if path.name.endswith(".db.py"):
+        return "db-py"
+    if path.suffix == ".py":
+        return "py"
+    raise ValueError(
+        f"Cannot infer runner format for '{path}'. "
+        "Use --format py, --format db-py, or --format ipynb."
+    )
+
+
+def run_file(
+    path: Path,
+    executor: DatabricksExecutor,
+    timeout: timedelta | None = None,
+    explicit_format: RunFormat | None = None,
+    inplace: bool = False,
+) -> ExecutionResult:
+    """Execute a supported runner input file.
+
+    Args:
+        path: Input file path.
+        executor: Initialized DatabricksExecutor with an active context.
+        timeout: Execution timeout.
+        explicit_format: Optional format override.
+        inplace: Whether to write notebook outputs back to an ipynb file.
+
+    Returns:
+        ExecutionResult from the selected runner.
+
+    Raises:
+        ValueError: If the format is unsupported or --inplace is invalid.
+    """
+    run_format = detect_run_format(path, explicit_format)
+    if inplace and run_format != "ipynb":
+        raise ValueError("--inplace is only supported for ipynb inputs")
+    if run_format == "py":
+        return run_py(path, executor, timeout=timeout)
+    if run_format == "db-py":
+        return run_db_py(path, executor, timeout=timeout)
+    if inplace:
+        return _run_ipynb_inplace(path, executor, timeout=timeout)
+    return run_ipynb(path, executor, timeout=timeout)
 
 
 def run_py(
@@ -227,20 +292,31 @@ def write_output(
     return out_path
 
 
-def _cli_dispatch(subcommand: str) -> None:
+def _cli_dispatch(default_format: RunFormat | None = None) -> None:
     """Shared dispatch logic for CLI entry points.
 
     Args:
-        subcommand: One of 'run_py', 'run_db_py'.
+        default_format: Optional format selected by a legacy entry point.
     """
     import argparse
     import sys
 
     from .config import Config
-    from .executor import DatabricksExecutor
+    from .executor import DatabricksExecutor, ExecutionResult
 
     parser = argparse.ArgumentParser()
     parser.add_argument("file", help="path to the file to execute")
+    parser.add_argument(
+        "--format",
+        choices=["py", "db-py", "ipynb"],
+        default=None,
+        help="input format override (default: infer from file extension)",
+    )
+    parser.add_argument(
+        "--inplace",
+        action="store_true",
+        help="write ipynb cell outputs back into the notebook",
+    )
     parser.add_argument(
         "--output-dir",
         default=".cache/outputs",
@@ -252,24 +328,48 @@ def _cli_dispatch(subcommand: str) -> None:
         default=600,
         help="execution timeout in seconds (default: 600)",
     )
+    parser.add_argument(
+        "--serverless",
+        action="store_true",
+        help="request Databricks serverless execution for non-interactive runs",
+    )
     parsed = parser.parse_args()
     file_path = Path(parsed.file)
     output_dir = parsed.output_dir
     timeout = timedelta(seconds=parsed.timeout)
+    explicit_format = cast(RunFormat | None, parsed.format or default_format)
+
+    if parsed.serverless:
+        parser.error(
+            "--serverless is recognized but not available yet. "
+            "The current runner uses Databricks Command Execution on classic "
+            "all-purpose clusters; see docs/serverless-execution-backend.md."
+        )
 
     config = Config.load()
     executor = DatabricksExecutor(config)
     executor.create_context()
     try:
-        fn = {"run_py": run_py, "run_db_py": run_db_py, "run_ipynb": run_ipynb}[
-            subcommand
-        ]
-        result = fn(file_path, executor, timeout=timeout)
+        try:
+            result = run_file(
+                file_path,
+                executor,
+                timeout=timeout,
+                explicit_format=explicit_format,
+                inplace=parsed.inplace,
+            )
+        except Exception as e:
+            result = ExecutionResult(status="error", error=str(e))
         write_output(result, file_path, output_dir)
     finally:
         executor.destroy_context()
     if result.status == "error":
         sys.exit(1)
+
+
+def cli_run() -> None:
+    """Unified CLI entry point for Databricks runner execution."""
+    _cli_dispatch()
 
 
 def cli_run_py() -> None:
@@ -282,7 +382,7 @@ def cli_run_py() -> None:
     ".cache/outputs"). Default execution timeout is 10 minutes; the cluster
     command is cancelled on timeout. Exits with code 1 on error or timeout.
     """
-    _cli_dispatch("run_py")
+    _cli_dispatch("py")
 
 
 def cli_run_db_py() -> None:
@@ -295,7 +395,7 @@ def cli_run_db_py() -> None:
     ".cache/outputs"). Default execution timeout is 10 minutes; the cluster
     command is cancelled on timeout. Exits with code 1 on error or timeout.
     """
-    _cli_dispatch("run_db_py")
+    _cli_dispatch("db-py")
 
 
 def cli_run_ipynb() -> None:
@@ -312,70 +412,8 @@ def cli_run_ipynb() -> None:
     Default execution timeout per cell is 10 minutes; the cluster command is
     cancelled on timeout. Exits with code 1 on error or timeout.
     """
-    import argparse
-    import sys
-
-    from .config import Config
-    from .executor import DatabricksExecutor, ExecutionResult
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("file", help="path to the .ipynb file to execute")
-    parser.add_argument(
-        "--inplace",
-        action="store_true",
-        help="write cell outputs back into the notebook (backup at <path>.bak)",
-    )
-    parser.add_argument(
-        "--output-dir",
-        default=".cache/outputs",
-        help="directory to write output file into (default: .cache/outputs)",
-    )
-    parser.add_argument(
-        "--timeout",
-        type=int,
-        default=600,
-        help="execution timeout per cell in seconds (default: 600)",
-    )
-    parsed = parser.parse_args()
-    file_path = Path(parsed.file)
-    inplace = parsed.inplace
-    output_dir = parsed.output_dir
-    timeout = timedelta(seconds=parsed.timeout)
-
-    config = Config.load()
-    executor = DatabricksExecutor(config)
-    executor.create_context()
-    try:
-        if inplace:
-            try:
-                result = _run_ipynb_inplace(file_path, executor, timeout=timeout)
-            except Exception as e:
-                result = ExecutionResult(status="error", error=str(e))
-        else:
-            result = run_ipynb(file_path, executor, timeout=timeout)
-        write_output(result, file_path, output_dir)
-    finally:
-        executor.destroy_context()
-    if result.status == "error":
-        sys.exit(1)
+    _cli_dispatch("ipynb")
 
 
 if __name__ == "__main__":
-    import sys
-
-    from .config import Config
-    from .executor import DatabricksExecutor
-
-    subcommand = sys.argv[1]
-    file_path = Path(sys.argv[2])
-    config = Config.load()
-    executor = DatabricksExecutor(config)
-    executor.create_context()
-    try:
-        fn = {"run_py": run_py, "run_db_py": run_db_py, "run_ipynb": run_ipynb}[
-            subcommand
-        ]
-        result = fn(file_path, executor)
-        write_output(result, file_path)
-    finally:
-        executor.destroy_context()
+    cli_run()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,12 +3,23 @@
 from __future__ import annotations
 
 import json
+from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from jupyter_databricks_kernel.executor import ExecutionResult
-from jupyter_databricks_kernel.runner import run_db_py, run_ipynb, run_py, write_output
+from jupyter_databricks_kernel.runner import (
+    cli_run,
+    detect_run_format,
+    run_db_py,
+    run_file,
+    run_ipynb,
+    run_py,
+    write_output,
+)
 
 if TYPE_CHECKING:
     pass
@@ -27,6 +38,55 @@ def _make_executor(output: str = "ok-output", error: str | None = None) -> Magic
         status=status, output=output, error=error
     )
     return executor
+
+
+# ---------------------------------------------------------------------------
+# run format dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestRunFormatDispatch:
+    """Tests for unified runner format dispatch."""
+
+    def test_detects_py_file(self, tmp_path: Path) -> None:
+        """Plain .py files dispatch to the py runner."""
+        assert detect_run_format(tmp_path / "script.py") == "py"
+
+    def test_detects_db_py_before_plain_py(self, tmp_path: Path) -> None:
+        """Databricks .db.py files dispatch to the db-py runner."""
+        assert detect_run_format(tmp_path / "notebook.db.py") == "db-py"
+
+    def test_detects_ipynb_file(self, tmp_path: Path) -> None:
+        """Notebook files dispatch to the ipynb runner."""
+        assert detect_run_format(tmp_path / "notebook.ipynb") == "ipynb"
+
+    def test_explicit_format_overrides_extension(self, tmp_path: Path) -> None:
+        """The --format equivalent overrides extension-based detection."""
+        assert detect_run_format(tmp_path / "script.py", "db-py") == "db-py"
+
+    def test_rejects_unknown_extension(self, tmp_path: Path) -> None:
+        """Unsupported extensions fail with an actionable error."""
+        with pytest.raises(ValueError, match="Cannot infer runner format"):
+            detect_run_format(tmp_path / "notes.txt")
+
+    def test_run_file_dispatches_to_db_py(self, tmp_path: Path) -> None:
+        """run_file dispatches to the selected runner implementation."""
+        py_file = tmp_path / "notebook.db.py"
+        py_file.write_text("print('db')\n")
+        executor = _make_executor()
+
+        result = run_file(py_file, executor)
+
+        assert result.status == "ok"
+        executor.execute.assert_called_once_with("print('db')\n", timeout=None)
+
+    def test_run_file_rejects_inplace_for_non_notebook(self, tmp_path: Path) -> None:
+        """--inplace is only valid for ipynb execution."""
+        py_file = tmp_path / "script.py"
+        py_file.write_text("print('py')\n")
+
+        with pytest.raises(ValueError, match="--inplace"):
+            run_file(py_file, _make_executor(), inplace=True)
 
 
 # ---------------------------------------------------------------------------
@@ -268,3 +328,82 @@ class TestWriteOutput:
         out_path = write_output(result, source)
         assert out_path.name.startswith("myfile.py.")
         assert out_path.name.endswith(".output.md")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCliRun:
+    """Tests for unified CLI behavior."""
+
+    def test_unified_cli_dispatches_by_extension(self, tmp_path: Path) -> None:
+        """cli_run infers the runner from the input file extension."""
+        import sys
+
+        py_file = tmp_path / "script.py"
+        py_file.write_text("print('cli')\n")
+        output_dir = tmp_path / "outputs"
+        executor = _make_executor(output="cli")
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["run", str(py_file), "--output-dir", str(output_dir)],
+            ),
+            patch("jupyter_databricks_kernel.config.Config.load"),
+            patch(
+                "jupyter_databricks_kernel.executor.DatabricksExecutor",
+                return_value=executor,
+            ),
+        ):
+            cli_run()
+
+        executor.create_context.assert_called_once_with()
+        executor.execute.assert_called_once_with(
+            "print('cli')\n", timeout=timedelta(seconds=600)
+        )
+        executor.destroy_context.assert_called_once_with()
+        assert list(output_dir.glob("script.py.*.output.md"))
+
+    def test_unified_cli_format_override(self, tmp_path: Path) -> None:
+        """cli_run supports an explicit --format override."""
+        import sys
+
+        py_file = tmp_path / "notebook.py"
+        py_file.write_text("print('db')\n")
+        executor = _make_executor(output="db")
+
+        with (
+            patch.object(sys, "argv", ["run", "--format", "db-py", str(py_file)]),
+            patch("jupyter_databricks_kernel.config.Config.load"),
+            patch(
+                "jupyter_databricks_kernel.executor.DatabricksExecutor",
+                return_value=executor,
+            ),
+        ):
+            cli_run()
+
+        executor.execute.assert_called_once_with(
+            "print('db')\n", timeout=timedelta(seconds=600)
+        )
+
+    def test_serverless_flag_fails_fast_with_documented_limitation(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--serverless is accepted by the parser but not silently routed."""
+        import sys
+
+        py_file = tmp_path / "script.py"
+        py_file.write_text("print('serverless')\n")
+
+        with (
+            patch.object(sys, "argv", ["run", "--serverless", str(py_file)]),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_run()
+
+        assert exc_info.value.code == 2
+        assert "--serverless is recognized" in capsys.readouterr().err

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -393,9 +393,7 @@ class TestCliRun:
             "print('db')\n", timeout=timedelta(seconds=600)
         )
 
-    def test_run_py_console_entry_alias_uses_py_format(
-        self, tmp_path: Path
-    ) -> None:
+    def test_run_py_console_entry_alias_uses_py_format(self, tmp_path: Path) -> None:
         """The run-py console entry keeps the legacy py default format."""
         import sys
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -13,6 +13,9 @@ import pytest
 from jupyter_databricks_kernel.executor import ExecutionResult
 from jupyter_databricks_kernel.runner import (
     cli_run,
+    cli_run_db_py,
+    cli_run_ipynb,
+    cli_run_py,
     detect_run_format,
     run_db_py,
     run_file,
@@ -389,6 +392,114 @@ class TestCliRun:
         executor.execute.assert_called_once_with(
             "print('db')\n", timeout=timedelta(seconds=600)
         )
+
+    def test_run_py_console_entry_alias_uses_py_format(
+        self, tmp_path: Path
+    ) -> None:
+        """The run-py console entry keeps the legacy py default format."""
+        import sys
+
+        py_file = tmp_path / "script.txt"
+        py_file.write_text("print('py alias')\n")
+        output_dir = tmp_path / "outputs"
+        executor = _make_executor(output="py alias")
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["run-py", str(py_file), "--output-dir", str(output_dir)],
+            ),
+            patch("jupyter_databricks_kernel.config.Config.load"),
+            patch(
+                "jupyter_databricks_kernel.executor.DatabricksExecutor",
+                return_value=executor,
+            ),
+        ):
+            cli_run_py()
+
+        executor.execute.assert_called_once_with(
+            "print('py alias')\n", timeout=timedelta(seconds=600)
+        )
+        assert list(output_dir.glob("script.txt.*.output.md"))
+
+    def test_run_db_py_console_entry_alias_uses_db_py_format(
+        self, tmp_path: Path
+    ) -> None:
+        """The run-db-py console entry keeps the legacy db-py default format."""
+        import sys
+
+        py_file = tmp_path / "notebook.txt"
+        py_file.write_text("# Databricks notebook\nprint('db alias')\n")
+        output_dir = tmp_path / "outputs"
+        executor = _make_executor(output="db alias")
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["run-db-py", str(py_file), "--output-dir", str(output_dir)],
+            ),
+            patch("jupyter_databricks_kernel.config.Config.load"),
+            patch(
+                "jupyter_databricks_kernel.executor.DatabricksExecutor",
+                return_value=executor,
+            ),
+        ):
+            cli_run_db_py()
+
+        executor.execute.assert_called_once_with(
+            "# Databricks notebook\nprint('db alias')\n",
+            timeout=timedelta(seconds=600),
+        )
+        assert list(output_dir.glob("notebook.txt.*.output.md"))
+
+    def test_run_ipynb_console_entry_alias_uses_ipynb_format(
+        self, tmp_path: Path
+    ) -> None:
+        """The run-ipynb console entry keeps the legacy ipynb default format."""
+        import sys
+
+        nb_path = tmp_path / "notebook.txt"
+        nb_path.write_text(
+            json.dumps(
+                {
+                    "nbformat": 4,
+                    "nbformat_minor": 5,
+                    "metadata": {},
+                    "cells": [
+                        {
+                            "cell_type": "code",
+                            "execution_count": None,
+                            "metadata": {},
+                            "outputs": [],
+                            "source": ["print('ipynb alias')"],
+                        }
+                    ],
+                }
+            )
+        )
+        output_dir = tmp_path / "outputs"
+        executor = _make_executor(output="ipynb alias")
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["run-ipynb", str(nb_path), "--output-dir", str(output_dir)],
+            ),
+            patch("jupyter_databricks_kernel.config.Config.load"),
+            patch(
+                "jupyter_databricks_kernel.executor.DatabricksExecutor",
+                return_value=executor,
+            ),
+        ):
+            cli_run_ipynb()
+
+        executor.execute.assert_called_once_with(
+            "print('ipynb alias')", timeout=timedelta(seconds=600)
+        )
+        assert list(output_dir.glob("notebook.txt.*.output.md"))
 
     def test_serverless_flag_fails_fast_with_documented_limitation(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import tomllib
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -341,6 +342,18 @@ class TestWriteOutput:
 class TestCliRun:
     """Tests for unified CLI behavior."""
 
+    def test_databricks_run_console_entry_is_primary_unified_command(self) -> None:
+        """databricks-run exposes the unified CLI while aliases remain wired."""
+        pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+        pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+        scripts = pyproject["project"]["scripts"]
+
+        assert scripts["databricks-run"] == "jupyter_databricks_kernel.runner:cli_run"
+        assert scripts["run"] == "jupyter_databricks_kernel.runner:cli_run"
+        assert scripts["run-py"] == "jupyter_databricks_kernel.runner:cli_run_py"
+        assert scripts["run-db-py"] == "jupyter_databricks_kernel.runner:cli_run_db_py"
+        assert scripts["run-ipynb"] == "jupyter_databricks_kernel.runner:cli_run_ipynb"
+
     def test_unified_cli_dispatches_by_extension(self, tmp_path: Path) -> None:
         """cli_run infers the runner from the input file extension."""
         import sys
@@ -354,7 +367,7 @@ class TestCliRun:
             patch.object(
                 sys,
                 "argv",
-                ["run", str(py_file), "--output-dir", str(output_dir)],
+                ["databricks-run", str(py_file), "--output-dir", str(output_dir)],
             ),
             patch("jupyter_databricks_kernel.config.Config.load"),
             patch(
@@ -380,7 +393,9 @@ class TestCliRun:
         executor = _make_executor(output="db")
 
         with (
-            patch.object(sys, "argv", ["run", "--format", "db-py", str(py_file)]),
+            patch.object(
+                sys, "argv", ["databricks-run", "--format", "db-py", str(py_file)]
+            ),
             patch("jupyter_databricks_kernel.config.Config.load"),
             patch(
                 "jupyter_databricks_kernel.executor.DatabricksExecutor",
@@ -509,7 +524,7 @@ class TestCliRun:
         py_file.write_text("print('serverless')\n")
 
         with (
-            patch.object(sys, "argv", ["run", "--serverless", str(py_file)]),
+            patch.object(sys, "argv", ["databricks-run", "--serverless", str(py_file)]),
             pytest.raises(SystemExit) as exc_info,
         ):
             cli_run()


### PR DESCRIPTION
## Summary

- Add a unified `run` CLI entry point for Python and notebook execution.
- Keep existing runner commands available for compatibility.
- Update README usage and focused runner tests.

## Verification

- Not run by worker-alt; PR created from already pushed branch.

Closes #251