### PR TITLE
feat: add uv exclude-newer supply-chain guard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,35 @@ uv run pytest
 | `uv run mypy src`    | Type check           |
 | `uv run jupyter-lab` | Start JupyterLab     |
 
+### 1.5. Dependency Freshness Policy
+
+`pyproject.toml` sets `[tool.uv] exclude-newer = "3 days"`, so `uv lock`
+and `uv sync`/`uv add` (when they need to re-resolve) refuse any package
+version published in the last 3 days. This is a supply-chain guard: it
+gives the community a short window to catch and report compromised or
+buggy releases before this project can adopt them, mirroring npm/pnpm's
+`minimumReleaseAge`. Background:
+[この記事](https://zenn.dev/watany/articles/a81a6122864539) ("これ入れたい。3daysで" — "I want to
+incorporate this, within 3 days" — was the original request that started
+this).
+
+The 3-day window is intentionally aligned to `.github/dependabot.yml`'s
+minimum `semver-patch-days: 3` cooldown tier, not its `default-days: 7`
+tier: `exclude-newer` only needs to be old enough to admit any version
+Dependabot could plausibly have already opened a PR for, and 3 days is the
+tightest tier Dependabot uses. A wider window (e.g. 7 days) would let CI's
+non-frozen `uv run pytest` re-resolve refuse a patch-level version
+Dependabot already proposed at day 3.
+
+This applies to the root package only. `examples/table-exporter` is a
+separately-locked demo project and does not currently have a matching
+`exclude-newer` setting or lock-check coverage (tracked as a fast-follow).
+
+If `uv add`/`uv lock` unexpectedly refuses a package you need, it is
+almost always because the version was published within the last 3 days —
+wait a few days, or use `exclude-newer-package` to override the cutoff for
+that one package if there is a specific reason to trust it early.
+
 ## 2. Project Structure
 
 ```text

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,15 +44,14 @@ uv run pytest
 
 ### 1.5. Dependency Freshness Policy
 
-`pyproject.toml` sets `[tool.uv] exclude-newer = "3 days"`, so `uv lock`
-and `uv sync`/`uv add` (when they need to re-resolve) refuse any package
-version published in the last 3 days. This is a supply-chain guard: it
-gives the community a short window to catch and report compromised or
-buggy releases before this project can adopt them, mirroring npm/pnpm's
-`minimumReleaseAge`. Background:
-[この記事](https://zenn.dev/watany/articles/a81a6122864539) ("これ入れたい。3daysで" — "I want to
-incorporate this, within 3 days" — was the original request that started
-this).
+`pyproject.toml` sets `[tool.uv] exclude-newer = "3 days"`, so `uv lock` and
+`uv sync`/`uv add` (when they need to re-resolve) refuse any package version
+published in the last 3 days. This is a supply-chain guard: it gives the
+community a short window to catch and report compromised or buggy releases
+before this project can adopt them, mirroring npm/pnpm's `minimumReleaseAge`.
+Background: [この記事](https://zenn.dev/watany/articles/a81a6122864539)
+("これ入れたい。3daysで" — "I want to incorporate this, within 3 days" — was the
+original request that started this).
 
 The 3-day window is intentionally aligned to `.github/dependabot.yml`'s
 minimum `semver-patch-days: 3` cooldown tier, not its `default-days: 7`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,8 @@ uv run pytest
 published in the last 3 days. This is a supply-chain guard: it gives the
 community a short window to catch and report compromised or buggy releases
 before this project can adopt them, mirroring npm/pnpm's `minimumReleaseAge`.
-Background: [この記事](https://zenn.dev/watany/articles/a81a6122864539)
-("これ入れたい。3daysで" — "I want to incorporate this, within 3 days" — was the
-original request that started this).
+Background:
+[uv's `exclude-newer` as a supply-chain guard](https://zenn.dev/watany/articles/a81a6122864539).
 
 The 3-day window is intentionally aligned to `.github/dependabot.yml`'s
 minimum `semver-patch-days: 3` cooldown tier, not its `default-days: 7`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ dev = [
     "ty>=0.0.32",
 ]
 
+[tool.uv]
+exclude-newer = "3 days"
+
 [tool.hatch.version]
 source = "vcs"
 

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,10 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
@@ -22,14 +26,14 @@ name = "aiohttp"
 version = "3.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohappyeyeballs", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "aiosignal", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "attrs", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "frozenlist", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "multidict", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "propcache", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
-    { name = "yarl", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "typing-extensions" },
+    { name = "yarl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
 wheels = [
@@ -140,8 +144,8 @@ name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "frozenlist", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
@@ -978,17 +982,17 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version < '3.12'" },
-    { name = "jedi", marker = "python_full_version < '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.12'" },
-    { name = "pexpect", marker = "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "stack-data", marker = "python_full_version < '3.12'" },
-    { name = "traitlets", marker = "python_full_version < '3.12'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/60/2111715ea11f39b1535bed6024b7dec7918b71e5e5d30855a5b503056b50/ipython-9.10.0.tar.gz", hash = "sha256:cd9e656be97618a0676d058134cd44e6dc7012c0e5cb36a9ce96a8c904adaf77", size = 4426526, upload-time = "2026-02-02T10:00:33.594Z" }
 wheels = [
@@ -1005,16 +1009,16 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.12'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.12'" },
-    { name = "jedi", marker = "python_full_version >= '3.12'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.12'" },
-    { name = "pexpect", marker = "python_full_version >= '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "stack-data", marker = "python_full_version >= '3.12'" },
-    { name = "traitlets", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/86/28/a4698eda5a8928a45d6b693578b135b753e14fa1c2b36ee9441e69a45576/ipython-9.11.0.tar.gz", hash = "sha256:2a94bc4406b22ecc7e4cb95b98450f3ea493a76bec8896cda11b78d7752a6667", size = 4427354, upload-time = "2026-03-05T08:57:30.549Z" }
 wheels = [
@@ -2741,9 +2745,9 @@ name = "yarl"
 version = "1.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "idna", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "multidict", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
-    { name = "propcache", marker = "python_full_version >= '3.12' and python_full_version < '3.14'" },
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Adds `[tool.uv] exclude-newer = "3 days"` to root `pyproject.toml` as a
supply-chain guard: `uv lock`/`uv sync`/`uv add` will refuse dependency
versions published within the last 3 days.

Closes #327

## Background

Requested via messenger (translated from Japanese "これ入れたい。3daysで" —
"I want to incorporate this. Within 3 days."), based on
https://zenn.dev/watany/articles/a81a6122864539, which describes uv's
`exclude-newer` setting as a response to recent Python-ecosystem
supply-chain incidents, mirroring npm/pnpm's `minimumReleaseAge`.

## Window choice

`exclude-newer = "3 days"`, aligned to `.github/dependabot.yml`'s minimum
`semver-patch-days: 3` cooldown tier rather than its `default-days: 7`
tier. Rationale: `exclude-newer` is a resolver ceiling, not an update
driver, so it only needs to be old enough to admit any version Dependabot
could plausibly have already opened a PR for. A wider window (e.g. 7 days)
would let CI's non-frozen `uv run pytest` re-resolve refuse a patch-level
version Dependabot already proposed at day 3.

## Scope

Root package only. `examples/table-exporter` is a separately-locked demo
project not covered by the existing `uv-lock-check` pre-commit hook;
extending it is tracked in #328 (fast-follow, not blocking this PR).

## Changes

- `pyproject.toml`: add `[tool.uv] exclude-newer = "3 days"`
- `uv.lock`: regenerated under the new constraint (no package version
  changes — only added `exclude-newer` metadata and simplified marker
  expressions)
- `CONTRIBUTING.md`: document the policy and its rationale

## Verification

- `uv lock`: resolves cleanly; diff shows no package version/name changes
- Enforcement proof: temporarily set `exclude-newer = "3650 days"`,
  confirmed `uv lock` fails (unsatisfiable `hatchling`/`hatch-vcs`
  build-system requirement, per uv's own filter hint); reverted to
  `"3 days"`, confirmed `uv lock` succeeds again
- `uv lock --check` (same check as CI's `uv-lock-check` hook): passes
- `uv sync --frozen` + `uv run pytest -m "not integration"`: 285 passed
- `uv run ruff check`, `uv run mypy src`: no issues