### PR TITLE
feat: extend uv exclude-newer + lock-check to table-exporter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,10 @@ tightest tier Dependabot uses. A wider window (e.g. 7 days) would let CI's
 non-frozen `uv run pytest` re-resolve refuse a patch-level version
 Dependabot already proposed at day 3.
 
-This applies to the root package only. `examples/table-exporter` is a
-separately-locked demo project and does not currently have a matching
-`exclude-newer` setting or lock-check coverage (tracked as a fast-follow).
+This applies to both the root package and `examples/table-exporter` (a
+separately-locked demo project): each carries its own
+`[tool.uv] exclude-newer = "3 days"` and a dedicated `uv-lock-check`
+pre-commit hook enforcing its lock freshness.
 
 If `uv add`/`uv lock` unexpectedly refuses a package you need, it is
 almost always because the version was published within the last 3 days —

--- a/examples/table-exporter/pyproject.toml
+++ b/examples/table-exporter/pyproject.toml
@@ -13,6 +13,9 @@ dependencies = [
     "jupyter-databricks-kernel",
 ]
 
+[tool.uv]
+exclude-newer = "3 days"
+
 [tool.uv.sources]
 jupyter-databricks-kernel = { path = "../.." }
 

--- a/examples/table-exporter/uv.lock
+++ b/examples/table-exporter/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "appnope"
 version = "0.1.4"

--- a/flake.nix
+++ b/flake.nix
@@ -124,6 +124,13 @@
                 pass_filenames = false;
               };
 
+              uv-lock-check-table-exporter = {
+                enable = true;
+                entry = "${pkgs.uv}/bin/uv lock --check --no-managed-python --python ${projectPython}/bin/python3 --project examples/table-exporter";
+                files = "^examples/table-exporter/(pyproject\\.toml|uv\\.lock)$";
+                pass_filenames = false;
+              };
+
               # === Secrets detection ===
               gitleaks = {
                 enable = true;


### PR DESCRIPTION
## Summary

Extends the `exclude-newer` supply-chain guard from #327/#329 to
`examples/table-exporter`, a separately-locked demo project that was
deliberately left out of scope there.

Closes #328

## Background

`[tool.uv] exclude-newer = "3 days"` was added to the root `pyproject.toml`
in #327/#329 as a supply-chain guard against recently-published (and
potentially compromised or buggy) package versions. `examples/table-exporter`
was excluded from that change because it's a separately-locked project
(`[tool.uv.sources]` path-dependency on the root package, own `uv.lock`) not
covered by the existing `uv-lock-check` pre-commit hook, and extending
`exclude-newer` there without matching enforcement would have produced
config that looked protected but wasn't. #328 tracked this as a fast-follow.

## Changes

- `examples/table-exporter/pyproject.toml`: add
  `[tool.uv] exclude-newer = "3 days"`, matching the root project's window.
- `flake.nix`: add a second pre-commit hook, `uv-lock-check-table-exporter`,
  scoped via `uv lock --check --project examples/table-exporter` and
  filtered to `examples/table-exporter/(pyproject.toml|uv.lock)`. A second
  hook instance was used rather than widening the existing hook's filter,
  since the existing hook's `entry` is a single fixed command
  (`pass_filenames = false`) that can't scope itself differently per
  matched file.
- `examples/table-exporter/uv.lock`: regenerated under the new constraint.
  Diff is additive only (new `[options]` metadata block); no package
  version changes.
- `CONTRIBUTING.md`: updated the Dependency Freshness Policy section
  (added in #329) to reflect that both the root package and
  `examples/table-exporter` now have their own `exclude-newer` setting and
  dedicated `uv-lock-check` hook — the prior wording said table-exporter
  still lacked this coverage, which this PR resolves.

## Verification

- `uv lock --project examples/table-exporter`: resolves cleanly, diff
  shows no package version/name changes
- `uv lock --check --project examples/table-exporter`: passes (failed
  before the lock regen, confirming the check is live)
- `uv lock --check` (root, unscoped): still passes, unaffected
- `uv sync --project examples/table-exporter --frozen`: installs cleanly
- `nix flake check`: all checks pass, including both `uv-lock-check` and
  `uv-lock-check-table-exporter` running side by side