### PR TITLE
fix(examples): preserve widget NameError

### DIFF
--- a/examples/table-exporter/common/params.py
+++ b/examples/table-exporter/common/params.py
@@ -6,9 +6,11 @@ import os
 def get_required_param(name: str) -> str:
     """Get a required parameter from dbutils widgets or environment variable."""
     try:
-        value = dbutils.widgets.get(name)  # type: ignore[name-defined]
+        databricks_utils = dbutils  # type: ignore[name-defined]
     except NameError:
         value = os.environ.get(name.upper(), "")
+    else:
+        value = databricks_utils.widgets.get(name)
     if not value:
         raise ValueError(f"Required parameter '{name}' is not set")
     return value
@@ -17,6 +19,7 @@ def get_required_param(name: str) -> str:
 def get_param(name: str, default: str = "") -> str:
     """Get an optional parameter from dbutils widgets or environment variable."""
     try:
-        return dbutils.widgets.get(name)  # type: ignore[name-defined]
+        databricks_utils = dbutils  # type: ignore[name-defined]
     except NameError:
         return os.environ.get(name.upper(), default)
+    return databricks_utils.widgets.get(name)

--- a/examples/table-exporter/common/params.py
+++ b/examples/table-exporter/common/params.py
@@ -6,8 +6,8 @@ import os
 def get_required_param(name: str) -> str:
     """Get a required parameter from dbutils widgets or environment variable."""
     try:
-        value = dbutils.widgets.get(name)  # type: ignore[name-defined]  # noqa: F821
-    except Exception:
+        value = dbutils.widgets.get(name)  # type: ignore[name-defined]
+    except NameError:
         value = os.environ.get(name.upper(), "")
     if not value:
         raise ValueError(f"Required parameter '{name}' is not set")
@@ -17,6 +17,6 @@ def get_required_param(name: str) -> str:
 def get_param(name: str, default: str = "") -> str:
     """Get an optional parameter from dbutils widgets or environment variable."""
     try:
-        return dbutils.widgets.get(name)  # type: ignore[name-defined]  # noqa: F821
-    except Exception:
+        return dbutils.widgets.get(name)  # type: ignore[name-defined]
+    except NameError:
         return os.environ.get(name.upper(), default)

--- a/tests/test_examples_table_exporter.py
+++ b/tests/test_examples_table_exporter.py
@@ -136,6 +136,56 @@ def test_main_defaults_file_format_to_json(monkeypatch, table_exporter_modules) 
     ]
 
 
+def test_params_fall_back_to_environment_without_dbutils(
+    monkeypatch, table_exporter_modules
+) -> None:
+    _main, _validator = table_exporter_modules
+    params = sys.modules["common.params"]
+    monkeypatch.delattr(params, "dbutils", raising=False)
+    monkeypatch.setenv("TABLE_NAME", "catalog.schema.table")
+
+    assert params.get_required_param("table_name") == "catalog.schema.table"
+    assert params.get_param("file_format", "json") == "json"
+
+
+def test_params_propagate_widget_name_error(
+    monkeypatch, table_exporter_modules
+) -> None:
+    _main, _validator = table_exporter_modules
+    params = sys.modules["common.params"]
+
+    class Widgets:
+        def get(self, name: str) -> str:
+            raise NameError("unrelated internal NameError")
+
+    class Dbutils:
+        widgets = Widgets()
+
+    monkeypatch.setattr(params, "dbutils", Dbutils(), raising=False)
+
+    with pytest.raises(NameError, match="unrelated internal NameError"):
+        params.get_param("file_format", "json")
+
+
+def test_params_prefer_widgets_over_environment(
+    monkeypatch, table_exporter_modules
+) -> None:
+    _main, _validator = table_exporter_modules
+    params = sys.modules["common.params"]
+
+    class Widgets:
+        def get(self, name: str) -> str:
+            return "widget-value"
+
+    class Dbutils:
+        widgets = Widgets()
+
+    monkeypatch.setattr(params, "dbutils", Dbutils(), raising=False)
+    monkeypatch.setenv("FILE_FORMAT", "environment-value")
+
+    assert params.get_param("file_format", "json") == "widget-value"
+
+
 @pytest.mark.parametrize(
     "path",
     [


### PR DESCRIPTION
## Summary

Fix the Ruff BLE001 CI failure in `examples/table-exporter/common/params.py` by narrowing the Databricks `dbutils` fallback boundary to missing injected globals only.

## Changes

- Preserve environment fallback when `dbutils` is unavailable.
- Propagate `NameError` raised inside `widgets.get` instead of masking it.
- Add regression coverage in `tests/test_examples_table_exporter.py` for fallback, error propagation, and widget precedence.

## Verification

- `uv run pytest tests/test_examples_table_exporter.py -k 'params'` (3 passed, 11 deselected)
- `uv run ruff check examples/table-exporter/common/params.py tests/test_examples_table_exporter.py`
- `uv run pytest tests/test_examples_table_exporter.py` (14 passed)
- `nix flake check --print-build-logs`
- `uv run --python 3.14 pytest -m 'not integration'` (288 passed, 5 deselected)
