### PR TITLE
feat(runner): sync project files before execution (#368)

### DIFF
--- a/src/jupyter_databricks_kernel/kernel.py
+++ b/src/jupyter_databricks_kernel/kernel.py
@@ -14,7 +14,7 @@ from ipykernel.kernelbase import Kernel
 from . import __version__
 from .config import Config
 from .executor import DatabricksExecutor
-from .sync import FileSync
+from .sync import FileSync, SetupError
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +180,7 @@ class DatabricksKernel(Kernel):
         """
         if self.file_sync is None or self.executor is None:
             return True, 0.0, 0
+        executor = self.executor
 
         if not self.file_sync.needs_sync():
             logger.debug("File sync skipped: no changes detected")
@@ -188,10 +189,6 @@ class DatabricksKernel(Kernel):
         try:
             logger.debug("Starting file sync")
             sync_start = time.time()
-
-            # Ensure executor context is created before sync
-            if self.executor.context_id is None:
-                self.executor.create_context()
 
             # Total steps: 4 local + 4 remote = 8
             total_steps = 8
@@ -211,32 +208,27 @@ class DatabricksKernel(Kernel):
                     step_msg = message
                 self._send_sync_progress(step_msg)
 
-            # Upload files with progress callback
-            # IMPORTANT: Pass executor to share execution context
-            stats = self.file_sync.sync(
-                on_progress=sync_progress, executor=self.executor
-            )
-            self._last_cluster_zip_path = stats.cluster_zip_path
-
-            # Execute setup steps on remote with progress
-            setup_steps = self.file_sync.get_setup_steps(stats.cluster_zip_path)
-            for i, (description, code) in enumerate(setup_steps):
-                step_num = 5 + i  # Steps 5-8
+            def execute_setup(description: str, code: str) -> Any:
+                step_num = 5 + len(executed_setup_steps)
                 result = self._run_with_spinner(
                     f"[{step_num}/{total_steps}] {description}...",
-                    self.executor.execute,
+                    executor.execute,
                     code,
                     allow_reconnect=False,
                 )
+                executed_setup_steps.append(description)
+                return result
 
-                if result.status != "ok":
-                    err_msg = f"Setup failed at '{description}': {result.error}\n"
-                    self.send_response(
-                        self.iopub_socket,
-                        "stream",
-                        {"name": "stderr", "text": err_msg},
-                    )
-                    return False, 0.0, 0
+            executed_setup_steps: list[str] = []
+            stats = self.file_sync.sync_and_setup(
+                executor,
+                on_progress=sync_progress,
+                execute_setup=execute_setup,
+            )
+            if stats is None:
+                logger.debug("File sync skipped: no changes detected")
+                return True, 0.0, 0
+            self._last_cluster_zip_path = stats.cluster_zip_path
 
             sync_elapsed = time.time() - sync_start
             logger.debug("File sync completed: %d files", stats.total_files)
@@ -247,6 +239,16 @@ class DatabricksKernel(Kernel):
 
             return True, sync_elapsed, stats.total_files
 
+        except SetupError as e:
+            self.send_response(
+                self.iopub_socket,
+                "stream",
+                {
+                    "name": "stderr",
+                    "text": f"Setup failed at '{e.description}': {e.error}\n",
+                },
+            )
+            return False, 0.0, 0
         except Exception as e:
             logger.warning("File sync failed: %s", e)
             self.send_response(

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -4,14 +4,29 @@ from __future__ import annotations
 
 import json
 import shutil
+import uuid
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
 
+from .sync import FileSync
+
 if TYPE_CHECKING:
+    from .config import Config
     from .executor import DatabricksExecutor, ExecutionResult
 
 RunFormat = Literal["py", "db-py", "ipynb"]
+
+
+def prepare_project(config: Config, executor: DatabricksExecutor) -> FileSync:
+    """Synchronize the configured project and prepare it on the driver."""
+    file_sync = FileSync(config, uuid.uuid4().hex[:8], caller="databricks-run")
+    try:
+        file_sync.sync_and_setup(executor)
+    except Exception:
+        file_sync.cleanup()
+        raise
+    return file_sync
 
 
 def detect_run_format(
@@ -349,8 +364,10 @@ def _cli_dispatch(default_format: RunFormat | None = None) -> None:
     config = Config.load()
     executor = DatabricksExecutor(config)
     executor.create_context()
+    file_sync: FileSync | None = None
     try:
         try:
+            file_sync = prepare_project(config, executor)
             result = run_file(
                 file_path,
                 executor,
@@ -362,6 +379,8 @@ def _cli_dispatch(default_format: RunFormat | None = None) -> None:
             result = ExecutionResult(status="error", error=str(e))
         write_output(result, file_path, output_dir)
     finally:
+        if file_sync is not None:
+            file_sync.cleanup()
         executor.destroy_context()
     if result.status == "error":
         sys.exit(1)

--- a/src/jupyter_databricks_kernel/sync.py
+++ b/src/jupyter_databricks_kernel/sync.py
@@ -137,10 +137,30 @@ with open("{cluster_zip_path}", "{mode}") as f:
 '''
 
 
+def build_command_api_archive_cleanup_command(cluster_zip_path: str) -> str:
+    """Build a remote command that removes a transferred project archive."""
+    return f'''
+import os
+try:
+    os.remove("{cluster_zip_path}")
+except FileNotFoundError:
+    pass
+'''
+
+
 class FileSizeError(Exception):
     """Exception raised when file size limits are exceeded."""
 
     pass
+
+
+class SetupError(RuntimeError):
+    """Raised when a remote project setup step cannot be completed."""
+
+    def __init__(self, description: str, error: str | None) -> None:
+        self.description = description
+        self.error = error
+        super().__init__(f"Setup failed at '{description}': {error}")
 
 
 @dataclass
@@ -586,6 +606,8 @@ class FileSync:
         self._pathspec_mtime: float = 0.0
         self._file_cache: FileCache | None = None
         self._command_context_id: str | None = None
+        self._transfer_context_id: str | None = None
+        self._cluster_zip_path: str | None = None
 
     def _ensure_client(self) -> WorkspaceClient:
         """Ensure the WorkspaceClient is initialized.
@@ -967,6 +989,7 @@ class FileSync:
 
         if context_id is None:
             raise RuntimeError("Failed to create or retrieve execution context")
+        self._transfer_context_id = context_id
 
         # Create target directory on cluster with UID fallback
         target_dir = f"/tmp/jupyter_databricks_kernel_{self.session_id}"
@@ -1007,6 +1030,7 @@ print(target_dir)
         if not re.match(r"^/tmp/jupyter_databricks_kernel_[a-zA-Z0-9_-]+$", actual_dir):
             raise ValueError(f"Invalid directory path from cluster: {actual_dir}")
         cluster_zip_path = f"{actual_dir}/project.zip"
+        self._cluster_zip_path = cluster_zip_path
 
         # Send chunks via Command API — decode directly on cluster.
         for i, chunk_b64 in enumerate(iter_command_api_base64_chunks(zip_data)):
@@ -1072,6 +1096,36 @@ print(target_dir)
         """
         steps = self.get_setup_steps(cluster_zip_path)
         return "\n".join(code for _, code in steps)
+
+    def sync_and_setup(
+        self,
+        executor: DatabricksExecutor,
+        on_progress: SyncProgressCallback | None = None,
+        execute_setup: Callable[[str, str], Any] | None = None,
+    ) -> SyncStats | None:
+        """Synchronize project files and prepare their remote execution path.
+
+        Returns ``None`` when synchronization is not needed.  Callers may
+        provide ``execute_setup`` to add presentation-specific progress while
+        sharing the same upload, extraction, working-directory, and sys.path
+        setup lifecycle.
+        """
+        if not self.needs_sync():
+            return None
+
+        if executor.context_id is None:
+            executor.create_context()
+
+        stats = self.sync(on_progress=on_progress, executor=executor)
+        for description, code in self.get_setup_steps(stats.cluster_zip_path):
+            result = (
+                execute_setup(description, code)
+                if execute_setup is not None
+                else executor.execute(code, allow_reconnect=False)
+            )
+            if result.status != "ok":
+                raise SetupError(description, result.error)
+        return stats
 
     def get_setup_steps(self, cluster_zip_path: str) -> list[tuple[str, str]]:
         """Generate setup steps to run on the remote cluster.
@@ -1191,22 +1245,27 @@ del _extract_dir, _cluster_zip_path
         ]
 
     def cleanup(self) -> None:
-        """Clean up DBFS files and command execution context.
+        """Remove the driver-local transfer archive and owned command context."""
+        if self._cluster_zip_path and self._transfer_context_id:
+            try:
+                from datetime import timedelta
 
-        Note: The /tmp/jupyter_databricks_kernel/<project>/ path on the cluster
-        driver is not cleaned up here as it is inaccessible from the kernel side
-        and gets overwritten on the next sync.
-        """
-        if not self._synced:
-            return
+                from databricks.sdk.service import compute
 
-        dbfs_dir = f"/tmp/jupyter_databricks_kernel/{self.session_id}"
-
-        try:
-            client = self._ensure_client()
-            client.dbfs.delete(dbfs_dir, recursive=True)
-        except Exception as e:
-            logger.debug("DBFS cleanup error (ignored): %s", e)
+                client = self._ensure_client()
+                client.command_execution.execute(
+                    cluster_id=self.config.cluster_id,
+                    context_id=self._transfer_context_id,
+                    language=compute.Language.PYTHON,
+                    command=build_command_api_archive_cleanup_command(
+                        self._cluster_zip_path
+                    ),
+                ).result(timeout=timedelta(minutes=5))
+            except Exception as e:
+                logger.debug("Transfer archive cleanup error (ignored): %s", e)
+            finally:
+                self._cluster_zip_path = None
+                self._transfer_context_id = None
 
         # Clean up self-managed command execution context
         if self._command_context_id and self.config.cluster_id:

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -7,7 +7,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from jupyter_databricks_kernel.executor import ExecutionResult
 from jupyter_databricks_kernel.kernel import DatabricksKernel
+from jupyter_databricks_kernel.sync import SetupError, SyncStats
 
 
 @pytest.fixture
@@ -121,6 +123,89 @@ class TestRestartBehavior:
         asyncio.run(mock_kernel.do_shutdown(restart=True))
 
         mock_kernel.file_sync.cleanup.assert_not_called()
+
+
+class TestSyncFiles:
+    """Tests for the kernel adapter around shared project synchronization."""
+
+    def test_sync_files_preserves_progress_and_executor_context(
+        self, mock_kernel: DatabricksKernel
+    ) -> None:
+        """The adapter shares its executor while retaining frontend progress."""
+        executor = MagicMock(context_id="shared-context")
+        executor.execute.return_value = ExecutionResult(status="ok")
+        file_sync = MagicMock()
+        file_sync.needs_sync.return_value = True
+        stats = SyncStats(total_files=2, cluster_zip_path="/tmp/project.zip")
+        progress_messages: list[str] = []
+        spinner_calls: list[tuple[str, str]] = []
+
+        def sync_and_setup(
+            executor_arg: object,
+            *,
+            on_progress: object,
+            execute_setup: object,
+        ) -> SyncStats:
+            assert executor_arg is executor
+            assert callable(on_progress)
+            assert callable(execute_setup)
+            on_progress("Collecting files...")
+            on_progress("Uploading (1 KB)...")
+            execute_setup("Configuring paths", "setup_code")
+            return stats
+
+        def run_with_spinner(
+            message: str, func: object, code: str, **kwargs: object
+        ) -> ExecutionResult:
+            spinner_calls.append((message, code))
+            assert callable(func)
+            return func(code, **kwargs)
+
+        mock_kernel.executor = executor
+        mock_kernel.file_sync = file_sync
+        file_sync.sync_and_setup.side_effect = sync_and_setup
+
+        with (
+            patch.object(mock_kernel, "_send_sync_progress", progress_messages.append),
+            patch.object(
+                mock_kernel, "_run_with_spinner", side_effect=run_with_spinner
+            ),
+        ):
+            success, elapsed, file_count = mock_kernel._sync_files()
+
+        assert success is True
+        assert elapsed >= 0
+        assert file_count == 2
+        assert progress_messages == [
+            "[1/8] Collecting files...",
+            "[4/8] Uploading (1 KB)...",
+        ]
+        assert spinner_calls == [("[5/8] Configuring paths...", "setup_code")]
+        executor.create_context.assert_not_called()
+        executor.execute.assert_called_once_with("setup_code", allow_reconnect=False)
+        assert mock_kernel._last_cluster_zip_path == "/tmp/project.zip"
+
+    def test_sync_files_reports_shared_setup_error(
+        self, mock_kernel: DatabricksKernel
+    ) -> None:
+        """A shared setup failure keeps the kernel's specific error response."""
+        mock_kernel.executor = MagicMock(context_id="shared-context")
+        mock_kernel.file_sync = MagicMock()
+        mock_kernel.file_sync.needs_sync.return_value = True
+        mock_kernel.file_sync.sync_and_setup.side_effect = SetupError(
+            "Extracting files", "permission denied"
+        )
+
+        success, elapsed, file_count = mock_kernel._sync_files()
+
+        assert success is False
+        assert elapsed == 0.0
+        assert file_count == 0
+        response = mock_kernel.send_response.call_args
+        assert response.args[1] == "stream"
+        assert response.args[2]["text"] == (
+            "Setup failed at 'Extracting files': permission denied\n"
+        )
 
 
 class TestReconnectionHandling:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,7 +7,7 @@ import tomllib
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
@@ -18,6 +18,7 @@ from jupyter_databricks_kernel.runner import (
     cli_run_ipynb,
     cli_run_py,
     detect_run_format,
+    prepare_project,
     run_db_py,
     run_file,
     run_ipynb,
@@ -91,6 +92,39 @@ class TestRunFormatDispatch:
 
         with pytest.raises(ValueError, match="--inplace"):
             run_file(py_file, _make_executor(), inplace=True)
+
+
+class TestProjectPreparation:
+    """Tests for shared project synchronization before runner execution."""
+
+    def test_uses_file_sync_shared_setup_lifecycle(self) -> None:
+        """Runner preparation delegates upload and remote setup to FileSync."""
+        config = MagicMock()
+        executor = MagicMock()
+        file_sync = MagicMock()
+
+        with patch(
+            "jupyter_databricks_kernel.runner.FileSync", return_value=file_sync
+        ) as file_sync_class:
+            prepare_project(config, executor)
+
+        file_sync_class.assert_called_once_with(config, ANY, caller="databricks-run")
+        file_sync.sync_and_setup.assert_called_once_with(executor)
+
+    def test_cleans_up_when_project_preparation_fails(self) -> None:
+        """A failed upload or setup does not leave runner sync state behind."""
+        config = MagicMock()
+        executor = MagicMock()
+        file_sync = MagicMock()
+        file_sync.sync_and_setup.side_effect = RuntimeError("setup failed")
+
+        with (
+            patch("jupyter_databricks_kernel.runner.FileSync", return_value=file_sync),
+            pytest.raises(RuntimeError, match="setup failed"),
+        ):
+            prepare_project(config, executor)
+
+        file_sync.cleanup.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------
@@ -354,6 +388,124 @@ class TestCliRun:
         assert scripts["run-db-py"] == "jupyter_databricks_kernel.runner:cli_run_db_py"
         assert scripts["run-ipynb"] == "jupyter_databricks_kernel.runner:cli_run_ipynb"
 
+    @pytest.mark.parametrize(
+        "file_name", ["script.py", "notebook.db.py", "notebook.ipynb"]
+    )
+    def test_cli_prepares_before_dispatch_and_cleans_up_for_each_format(
+        self, tmp_path: Path, file_name: str
+    ) -> None:
+        """Every unified format prepares the project before dispatching it."""
+        import sys
+
+        file_path = tmp_path / file_name
+        output_dir = tmp_path / "outputs"
+        config = MagicMock()
+        executor = _make_executor()
+        file_sync = MagicMock()
+        events: list[str] = []
+
+        def prepare(config_arg: object, executor_arg: object) -> MagicMock:
+            assert config_arg is config
+            assert executor_arg is executor
+            events.append("prepare")
+            return file_sync
+
+        def dispatch(*args: object, **kwargs: object) -> ExecutionResult:
+            events.append("dispatch")
+            return ExecutionResult(status="ok", output="done")
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["databricks-run", str(file_path), "--output-dir", str(output_dir)],
+            ),
+            patch("jupyter_databricks_kernel.config.Config.load", return_value=config),
+            patch(
+                "jupyter_databricks_kernel.executor.DatabricksExecutor",
+                return_value=executor,
+            ),
+            patch(
+                "jupyter_databricks_kernel.runner.prepare_project", side_effect=prepare
+            ),
+            patch("jupyter_databricks_kernel.runner.run_file", side_effect=dispatch),
+        ):
+            cli_run()
+
+        assert events == ["prepare", "dispatch"]
+        file_sync.cleanup.assert_called_once_with()
+        executor.destroy_context.assert_called_once_with()
+
+    def test_cli_preparation_failure_writes_error_and_destroys_context(
+        self, tmp_path: Path
+    ) -> None:
+        """Preparation errors retain the CLI's output, exit, and context lifecycle."""
+        import sys
+
+        file_path = tmp_path / "script.py"
+        output_dir = tmp_path / "outputs"
+        executor = _make_executor()
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["databricks-run", str(file_path), "--output-dir", str(output_dir)],
+            ),
+            patch("jupyter_databricks_kernel.config.Config.load"),
+            patch(
+                "jupyter_databricks_kernel.executor.DatabricksExecutor",
+                return_value=executor,
+            ),
+            patch(
+                "jupyter_databricks_kernel.runner.prepare_project",
+                side_effect=RuntimeError("setup failed"),
+            ),
+            pytest.raises(SystemExit) as exc_info,
+        ):
+            cli_run()
+
+        assert exc_info.value.code == 1
+        assert "setup failed" in next(output_dir.glob("*.output.md")).read_text()
+        executor.destroy_context.assert_called_once_with()
+
+    def test_cli_ipynb_preserves_inplace_after_preparation(
+        self, tmp_path: Path
+    ) -> None:
+        """The shared preparation adapter preserves notebook in-place dispatch."""
+        import sys
+
+        file_path = tmp_path / "notebook.ipynb"
+        executor = _make_executor()
+        file_sync = MagicMock()
+        events: list[str] = []
+
+        def prepare(*args: object) -> MagicMock:
+            events.append("prepare")
+            return file_sync
+
+        def dispatch(*args: object, **kwargs: object) -> ExecutionResult:
+            events.append("dispatch")
+            assert kwargs["inplace"] is True
+            return ExecutionResult(status="ok")
+
+        with (
+            patch.object(sys, "argv", ["databricks-run", str(file_path), "--inplace"]),
+            patch("jupyter_databricks_kernel.config.Config.load"),
+            patch(
+                "jupyter_databricks_kernel.executor.DatabricksExecutor",
+                return_value=executor,
+            ),
+            patch(
+                "jupyter_databricks_kernel.runner.prepare_project", side_effect=prepare
+            ),
+            patch("jupyter_databricks_kernel.runner.run_file", side_effect=dispatch),
+        ):
+            cli_run()
+
+        assert events == ["prepare", "dispatch"]
+        file_sync.cleanup.assert_called_once_with()
+
     def test_unified_cli_dispatches_by_extension(self, tmp_path: Path) -> None:
         """cli_run infers the runner from the input file extension."""
         import sys
@@ -374,6 +526,7 @@ class TestCliRun:
                 "jupyter_databricks_kernel.executor.DatabricksExecutor",
                 return_value=executor,
             ),
+            patch("jupyter_databricks_kernel.runner.prepare_project"),
         ):
             cli_run()
 
@@ -401,6 +554,7 @@ class TestCliRun:
                 "jupyter_databricks_kernel.executor.DatabricksExecutor",
                 return_value=executor,
             ),
+            patch("jupyter_databricks_kernel.runner.prepare_project"),
         ):
             cli_run()
 
@@ -428,6 +582,7 @@ class TestCliRun:
                 "jupyter_databricks_kernel.executor.DatabricksExecutor",
                 return_value=executor,
             ),
+            patch("jupyter_databricks_kernel.runner.prepare_project"),
         ):
             cli_run_py()
 
@@ -458,6 +613,7 @@ class TestCliRun:
                 "jupyter_databricks_kernel.executor.DatabricksExecutor",
                 return_value=executor,
             ),
+            patch("jupyter_databricks_kernel.runner.prepare_project"),
         ):
             cli_run_db_py()
 
@@ -506,6 +662,7 @@ class TestCliRun:
                 "jupyter_databricks_kernel.executor.DatabricksExecutor",
                 return_value=executor,
             ),
+            patch("jupyter_databricks_kernel.runner.prepare_project"),
         ):
             cli_run_ipynb()
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -21,7 +21,9 @@ from jupyter_databricks_kernel.sync import (
     FileCache,
     FileSizeError,
     FileSync,
+    SetupError,
     SyncStats,
+    build_command_api_archive_cleanup_command,
     build_command_api_chunk_write_command,
     count_command_api_base64_chunks,
     get_cache_dir,
@@ -769,6 +771,100 @@ class TestFormatSize:
         """Test formatting megabytes."""
         assert file_sync._format_size(1024 * 1024) == "1 MB"
         assert file_sync._format_size(int(2.5 * 1024 * 1024)) == "2.5 MB"
+
+
+class TestSyncAndSetup:
+    """Tests for the shared upload and remote setup lifecycle."""
+
+    def test_reuses_executor_for_upload_and_setup(self, file_sync: FileSync) -> None:
+        """One executor context performs both project upload and setup steps."""
+        executor = MagicMock(context_id="context-id")
+        stats = SyncStats(cluster_zip_path="/tmp/project.zip")
+        setup_steps = [("Configuring paths", "sys.path.insert(0, '/tmp/project')")]
+        executor.execute.return_value = MagicMock(status="ok")
+
+        with (
+            patch.object(file_sync, "needs_sync", return_value=True),
+            patch.object(file_sync, "sync", return_value=stats) as sync,
+            patch.object(file_sync, "get_setup_steps", return_value=setup_steps),
+        ):
+            result = file_sync.sync_and_setup(executor)
+
+        assert result is stats
+        sync.assert_called_once_with(on_progress=None, executor=executor)
+        executor.create_context.assert_not_called()
+        executor.execute.assert_called_once_with(
+            "sys.path.insert(0, '/tmp/project')", allow_reconnect=False
+        )
+
+    def test_skips_upload_and_setup_when_no_sync_is_needed(
+        self, file_sync: FileSync
+    ) -> None:
+        """A clean project does not create a context or execute setup code."""
+        executor = MagicMock()
+
+        with (
+            patch.object(file_sync, "needs_sync", return_value=False),
+            patch.object(file_sync, "sync") as sync,
+        ):
+            result = file_sync.sync_and_setup(executor)
+
+        assert result is None
+        sync.assert_not_called()
+        executor.create_context.assert_not_called()
+        executor.execute.assert_not_called()
+
+    def test_reports_the_failed_remote_setup_step(self, file_sync: FileSync) -> None:
+        """Setup errors identify the step that did not complete."""
+        executor = MagicMock(context_id="context-id")
+        stats = SyncStats(cluster_zip_path="/tmp/project.zip")
+        executor.execute.return_value = MagicMock(
+            status="error", error="permission denied"
+        )
+
+        with (
+            patch.object(file_sync, "needs_sync", return_value=True),
+            patch.object(file_sync, "sync", return_value=stats),
+            patch.object(
+                file_sync,
+                "get_setup_steps",
+                return_value=[("Extracting files", "extract()")],
+            ),
+            pytest.raises(SetupError, match="Extracting files") as exc_info,
+        ):
+            file_sync.sync_and_setup(executor)
+
+        assert exc_info.value.description == "Extracting files"
+        assert exc_info.value.error == "permission denied"
+
+    def test_cleanup_deletes_uid_fallback_transfer_archive(
+        self, file_sync: FileSync
+    ) -> None:
+        """Cleanup removes the actual driver-local archive via its upload context."""
+        client = MagicMock()
+        file_sync.client = client
+        file_sync._cluster_zip_path = (
+            "/tmp/jupyter_databricks_kernel_test-session_1000/project.zip"
+        )
+        file_sync._transfer_context_id = "caller-context"
+
+        file_sync.cleanup()
+
+        command = client.command_execution.execute.call_args.kwargs["command"]
+        assert "os.remove" in command
+        assert "jupyter_databricks_kernel_test-session_1000/project.zip" in command
+        assert client.command_execution.execute.call_args.kwargs["context_id"] == (
+            "caller-context"
+        )
+        assert file_sync._cluster_zip_path is None
+        assert file_sync._transfer_context_id is None
+
+    def test_archive_cleanup_command_ignores_absent_archive(self) -> None:
+        """A repeated cleanup does not fail when setup already removed the archive."""
+        command = build_command_api_archive_cleanup_command("/tmp/project.zip")
+
+        assert 'os.remove("/tmp/project.zip")' in command
+        assert "except FileNotFoundError" in command
 
 
 class TestSyncStats:


### PR DESCRIPTION
Reuse shared project synchronization and remote setup before runner execution, and clean up the actual Command Execution API transfer archive in its upload context. Validation: pytest suites passed (302 passed, 5 skipped); ruff and mypy passed. Closes #368.