### PR TITLE
feat(sync): add diagnostics benchmark surface

### DIFF
--- a/docs/sync-benchmark.md
+++ b/docs/sync-benchmark.md
@@ -1,0 +1,266 @@
+# Sync Benchmark
+
+Use this workflow to compare file synchronization latency before and after sync
+changes. It is manual because it needs a real Databricks workspace,
+authentication, and a classic all-purpose cluster, but the local fixture and
+mutations are deterministic.
+
+Do not use a project example that reads or writes real tables, DBFS paths, S3
+locations, or workspace data. The benchmark source tree below contains only
+local Python files and one `pyproject.toml`.
+
+## Prerequisites
+
+- Databricks authentication is configured for the target workspace.
+- `DATABRICKS_CLUSTER_ID` or the active Databricks profile selects a running or
+  startable classic all-purpose cluster.
+- The checkout dependencies are installed with `uv sync`.
+- Public reports replace cluster IDs, host names, user names, service principal
+  names, profile names, local absolute paths, and workspace URLs with stable
+  labels such as `<cluster-a>` or `<profile-dev>`.
+
+Set package-scoped debug logging so phase-level sync diagnostics are visible:
+
+```bash
+export JUPYTER_DATABRICKS_KERNEL_LOG_LEVEL=DEBUG
+```
+
+## Create The Fixture
+
+Run these commands from the repository root. They replace only the benchmark
+fixture under `.cache/sync-benchmark-fixture`.
+
+```bash
+rm -rf .cache/sync-benchmark-fixture
+mkdir -p .cache/sync-benchmark-fixture/pkg
+python - <<'PY'
+from pathlib import Path
+
+root = Path(".cache/sync-benchmark-fixture")
+(root / "pyproject.toml").write_text(
+    "[tool.jupyter-databricks-kernel.sync]\n"
+    'source = "."\n'
+    "use_gitignore = false\n"
+    "compression_level = 1\n"
+)
+(root / "main.py").write_text(
+    "from pkg.module_000 import value\n"
+    "print(value())\n"
+)
+(root / "pkg" / "__init__.py").write_text("")
+for index in range(100):
+    body = f"def value():\n    return 'module-{index:03d}'\n"
+    (root / "pkg" / f"module_{index:03d}.py").write_text(body)
+PY
+```
+
+The fixture contains 103 synchronized files: one `pyproject.toml`, one
+`main.py`, one package `__init__.py`, and 100 small module files.
+
+Record the exact revision and sync configuration before every benchmark run:
+
+```bash
+git rev-parse --short HEAD
+sed -n '1,20p' .cache/sync-benchmark-fixture/pyproject.toml
+```
+
+## Run The Persistent Benchmark
+
+The warm no-change case must run in one Python process with one `FileSync`
+instance and one executor. Separate CLI invocations create separate sync
+lifecycles and do not measure the persistent no-change path.
+
+```bash
+python - <<'PY'
+from __future__ import annotations
+
+import shutil
+import statistics
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from jupyter_databricks_kernel.config import Config
+from jupyter_databricks_kernel.executor import DatabricksExecutor
+from jupyter_databricks_kernel.sync import FileSync
+
+fixture = Path(".cache/sync-benchmark-fixture").resolve()
+baseline = Path(".cache/sync-benchmark-fixture.baseline")
+if baseline.exists():
+    shutil.rmtree(baseline)
+shutil.copytree(fixture, baseline)
+
+
+def restore() -> None:
+    if fixture.exists():
+        shutil.rmtree(fixture)
+    shutil.copytree(baseline, fixture)
+
+
+def mutate_one_small_file() -> None:
+    path = fixture / "pkg" / "module_001.py"
+    path.write_text("def value():\n    return 'module-001-edited'\n")
+
+
+def create_one_file() -> None:
+    (fixture / "pkg" / "created.py").write_text("CREATED = True\n")
+
+
+def delete_one_file() -> None:
+    (fixture / "pkg" / "module_002.py").unlink()
+
+
+def rename_one_file() -> None:
+    (fixture / "pkg" / "module_003.py").rename(fixture / "pkg" / "renamed_003.py")
+
+
+def change_several_files() -> None:
+    for index in range(10, 20):
+        path = fixture / "pkg" / f"module_{index:03d}.py"
+        path.write_text(f"def value():\n    return 'module-{index:03d}-edited'\n")
+
+
+def add_many_small_files() -> None:
+    for index in range(200):
+        (fixture / "pkg" / f"extra_{index:03d}.py").write_text(
+            f"EXTRA_VALUE = {index}\n"
+        )
+
+
+def run_case(
+    label: str,
+    mutate: Callable[[], None] | None,
+    *,
+    runs: int = 5,
+    persistent_warm: bool = False,
+) -> None:
+    totals: list[float] = []
+    for run in range(1, runs + 1):
+        restore()
+        config = Config.load(fixture / "pyproject.toml")
+        config.base_path = fixture
+        sync = FileSync(config, f"bench-{label.replace(' ', '-')}-{run}")
+        executor = DatabricksExecutor(config)
+        try:
+            if persistent_warm:
+                sync.sync_and_setup(executor)
+                started = time.perf_counter()
+                result = sync.sync_and_setup(executor)
+                total = time.perf_counter() - started
+                stats = result
+            else:
+                if mutate is not None:
+                    sync.sync_and_setup(executor)
+                    mutate()
+                stats = sync.sync_and_setup(executor)
+                total = stats.total_duration if stats is not None else 0.0
+            upload = stats.upload_duration if stats is not None else 0.0
+            changed = stats.changed_files if stats is not None else 0
+            deleted = stats.deleted_files if stats is not None else 0
+            total_files = stats.total_files if stats is not None else 0
+            source_size = stats.source_size if stats is not None else 0
+            archive_size = stats.archive_size if stats is not None else 0
+            chunks = stats.chunk_count if stats is not None else 0
+            remote_calls = stats.remote_calls if stats is not None else 0
+            totals.append(total)
+            print(
+                f"{label}\trun={run}\tpreparation_total_seconds={total:.6f}"
+                f"\tupload_seconds={upload:.6f}\tchanged_files={changed}"
+                f"\tdeleted_files={deleted}\ttotal_files={total_files}"
+                f"\tsource_size_bytes={source_size}"
+                f"\tarchive_size_bytes={archive_size}\tchunks={chunks}"
+                f"\tremote_calls={remote_calls}"
+            )
+        finally:
+            sync.cleanup()
+            executor.destroy_context()
+    print(f"{label}\tmedian_seconds={statistics.median(totals):.6f}")
+
+
+cases: list[tuple[str, Callable[[], None] | None]] = [
+    ("cold first sync", None),
+    ("one small file changed", mutate_one_small_file),
+    ("one file created", create_one_file),
+    ("one file deleted", delete_one_file),
+    ("one file renamed", rename_one_file),
+    ("several small files changed", change_several_files),
+    ("many small files added", add_many_small_files),
+]
+
+run_case("persistent warm no-change", None, persistent_warm=True)
+for case_label, case_mutation in cases:
+    run_case(case_label, case_mutation)
+restore()
+PY
+```
+
+## Reset Between Candidate Revisions
+
+Before switching branches, changing sync code, or repeating a candidate run,
+reset the fixture and remove the copied baseline:
+
+```bash
+rm -rf .cache/sync-benchmark-fixture .cache/sync-benchmark-fixture.baseline
+```
+
+Then recreate the fixture from the commands above. Keep the same cluster,
+profile, Python environment, fixture counts, and sync configuration when
+comparing revisions.
+
+For a cold remote directory run, set a new extraction directory before starting
+the Python benchmark process:
+
+```bash
+export JUPYTER_DATABRICKS_KERNEL_EXTRACT_DIR=/tmp/jdk-sync-benchmark-$(date +%s)
+```
+
+For a remote-state-missing run, restart the cluster or remove only the remote
+benchmark extraction directory, then run the benchmark process again.
+
+## Result Format
+
+Record one row per case and revision. Report medians from at least five runs.
+
+```text
+Revision: <git-sha>
+Cluster: <cluster-a>
+Profile: <profile-dev>
+Python: <version>
+Sync config: source=., use_gitignore=false, compression_level=1
+Fixture: 103 baseline files, 100 modules, many-file case adds 200 files
+
+Case: persistent warm no-change
+Median total: <ms>
+Lifecycle: one FileSync instance, one DatabricksExecutor, one Python process
+
+Case: one small file changed
+Median total: <ms>
+Upload total: <ms>
+Discovery: <ms>
+Change detection: <ms>
+Archive creation: <ms>
+Context setup: <ms>
+Transfer: <ms>
+Remote apply: <ms>
+Path setup: <ms>
+Preparation total: <ms>
+Files: <changed> changed / <total> total
+Deleted: <deleted>
+Source size: <bytes-or-human-size>
+Payload: <bytes-or-human-size> / <chunks> chunks
+Remote calls: <count>
+Mode: full
+```
+
+Include runner exit code and sync failure messages only when they are relevant
+and sanitized. Do not include Databricks tokens, Jupyter connection secrets,
+workspace URLs, cluster IDs, profile names, local absolute paths, or output that
+contains private workspace data in public issue or PR comments.
+
+## Decision Gate
+
+Use the collected measurements before implementing incremental sync. If the
+warm one-file edit case is dominated by Command Execution API round trips,
+prefer round-trip consolidation before archive or diff complexity. If archive
+creation or payload transfer remains dominant after low-risk fixes, then
+prototype incremental sync behind an explicit fallback path.

--- a/src/jupyter_databricks_kernel/runner.py
+++ b/src/jupyter_databricks_kernel/runner.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import logging
+import os
 import shutil
 import uuid
 from datetime import datetime, timedelta
@@ -16,6 +18,36 @@ if TYPE_CHECKING:
     from .executor import DatabricksExecutor, ExecutionResult
 
 RunFormat = Literal["py", "db-py", "ipynb"]
+PACKAGE_LOGGER_NAME = "jupyter_databricks_kernel"
+CLI_LOG_HANDLER_NAME = "jupyter_databricks_kernel.cli"
+
+
+def configure_cli_logging() -> None:
+    """Configure runner logging from the optional log-level environment value."""
+    level_name = os.environ.get("JUPYTER_DATABRICKS_KERNEL_LOG_LEVEL")
+    if not level_name:
+        return
+
+    level = getattr(logging, level_name.upper(), None)
+    if not isinstance(level, int):
+        return
+
+    package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+    package_logger.setLevel(level)
+    package_logger.propagate = False
+
+    for handler in package_logger.handlers:
+        if handler.get_name() == CLI_LOG_HANDLER_NAME:
+            handler.setLevel(level)
+            return
+
+    handler = logging.StreamHandler()
+    handler.set_name(CLI_LOG_HANDLER_NAME)
+    handler.setLevel(level)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    )
+    package_logger.addHandler(handler)
 
 
 def prepare_project(config: Config, executor: DatabricksExecutor) -> FileSync:
@@ -319,6 +351,8 @@ def _cli_dispatch(default_format: RunFormat | None = None) -> None:
     from .config import Config
     from .executor import DatabricksExecutor, ExecutionResult
 
+    configure_cli_logging()
+
     parser = argparse.ArgumentParser()
     parser.add_argument("file", help="path to the file to execute")
     parser.add_argument(
@@ -363,7 +397,6 @@ def _cli_dispatch(default_format: RunFormat | None = None) -> None:
 
     config = Config.load()
     executor = DatabricksExecutor(config)
-    executor.create_context()
     file_sync: FileSync | None = None
     try:
         try:

--- a/src/jupyter_databricks_kernel/sync.py
+++ b/src/jupyter_databricks_kernel/sync.py
@@ -173,6 +173,21 @@ class SyncStats:
     total_files: int = 0
     sync_duration: float = 0.0
     cluster_zip_path: str = ""
+    deleted_files: int = 0
+    upload_duration: float = 0.0
+    total_duration: float = 0.0
+    source_size: int = 0
+    archive_size: int = 0
+    chunk_count: int = 0
+    remote_calls: int = 0
+    mode: str = "full"
+    discovery_duration: float = 0.0
+    change_detection_duration: float = 0.0
+    archive_creation_duration: float = 0.0
+    context_setup_duration: float = 0.0
+    transfer_duration: float = 0.0
+    remote_apply_duration: float = 0.0
+    path_setup_duration: float = 0.0
 
 
 @dataclass
@@ -944,26 +959,36 @@ class FileSync:
 
         from databricks.sdk.service import compute
 
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Get all files and validate sizes (also returns size info for reuse)
         source_path = self._get_source_path()
 
+        discovery_start = time.perf_counter()
         all_files = self._get_all_files(on_progress=on_progress)
         file_sizes = self._validate_sizes(all_files, source_path)
+        discovery_duration = time.perf_counter() - discovery_start
         total_files = len(all_files)
 
         # Get changed files and statistics (reuse size info to avoid duplicate stat())
         file_cache = self._get_file_cache()
+        change_detection_start = time.perf_counter()
         changed_files, stats, computed_hashes = file_cache.get_changed_files(
             all_files, file_sizes, on_progress=on_progress
         )
+        stats.change_detection_duration = time.perf_counter() - change_detection_start
+        stats.discovery_duration = discovery_duration
+        stats.total_files = total_files
+        stats.source_size = sum(file_sizes.values())
 
         if on_progress:
             on_progress(f"Creating archive ({total_files} files)...")
 
         # Create zip archive (reuse file list to avoid duplicate os.walk)
+        archive_start = time.perf_counter()
         zip_data = self._create_zip(all_files)
+        stats.archive_creation_duration = time.perf_counter() - archive_start
+        stats.archive_size = len(zip_data)
 
         if on_progress:
             on_progress(f"Uploading ({self._format_size(len(zip_data))})...")
@@ -972,8 +997,10 @@ class FileSync:
         client = self._ensure_client()
 
         num_chunks = count_command_api_base64_chunks(len(zip_data))
+        stats.chunk_count = num_chunks
 
         # Use executor's context if provided, otherwise create minimal execution context
+        context_setup_start = time.perf_counter()
         context_id: str | None
         if executor and executor.context_id:
             context_id = executor.context_id
@@ -982,6 +1009,7 @@ class FileSync:
                 cluster_id=self.config.cluster_id,
                 language=compute.Language.PYTHON,
             ).result()
+            stats.remote_calls += 1
             self._command_context_id = response.id if response else None
             context_id = self._command_context_id
         else:
@@ -1013,6 +1041,7 @@ print(target_dir)
             language=compute.Language.PYTHON,
             command=mkdir_code,
         ).result(timeout=timedelta(minutes=5))
+        stats.remote_calls += 1
 
         if result and result.results and result.results.cause:
             raise RuntimeError(f"Failed to create directory: {result.results.cause}")
@@ -1031,8 +1060,10 @@ print(target_dir)
             raise ValueError(f"Invalid directory path from cluster: {actual_dir}")
         cluster_zip_path = f"{actual_dir}/project.zip"
         self._cluster_zip_path = cluster_zip_path
+        stats.context_setup_duration = time.perf_counter() - context_setup_start
 
         # Send chunks via Command API — decode directly on cluster.
+        transfer_start = time.perf_counter()
         for i, chunk_b64 in enumerate(iter_command_api_base64_chunks(zip_data)):
             mode = "wb" if i == 0 else "ab"
             code = build_command_api_chunk_write_command(
@@ -1044,6 +1075,7 @@ print(target_dir)
                 language=compute.Language.PYTHON,
                 command=code,
             ).result(timeout=timedelta(minutes=5))
+            stats.remote_calls += 1
 
             if result and result.results and result.results.cause:
                 raise RuntimeError(
@@ -1057,9 +1089,11 @@ print(target_dir)
 
             if on_progress:
                 on_progress(f"Transferred chunk {i + 1}/{num_chunks}...")
+        stats.transfer_duration = time.perf_counter() - transfer_start
 
         # Remove deleted files from cache
         deleted_files = file_cache.get_deleted_files(all_files)
+        stats.deleted_files = len(deleted_files)
         for rel_path in deleted_files:
             file_cache.remove(rel_path)
 
@@ -1068,17 +1102,39 @@ print(target_dir)
         file_cache.save()
         self._synced = True
 
-        # Calculate duration and set path
-        stats.sync_duration = time.time() - start_time
+        # Calculate upload duration and set path. sync_duration remains as a
+        # backward-compatible alias for the total duration of the returned
+        # operation; for sync(), the operation is upload-only.
+        stats.upload_duration = time.perf_counter() - start_time
+        stats.total_duration = stats.upload_duration
+        stats.sync_duration = stats.total_duration
         stats.cluster_zip_path = cluster_zip_path
 
         # Log statistics
         logger.info(
-            "Sync complete: %d changed (%s), %d skipped, %.1fs",
+            "Sync upload complete: %d changed (%s), %d deleted, %d skipped, "
+            "%s archive, %d chunks, %d remote calls, %.1fs",
             stats.changed_files,
             self._format_size(stats.changed_size),
+            stats.deleted_files,
             stats.skipped_files,
-            stats.sync_duration,
+            self._format_size(stats.archive_size),
+            stats.chunk_count,
+            stats.remote_calls,
+            stats.upload_duration,
+        )
+        logger.debug(
+            "Sync upload diagnostics: discovery=%.3fs change_detection=%.3fs "
+            "archive_creation=%.3fs context_setup=%.3fs transfer=%.3fs "
+            "source_size=%s archive_size=%s mode=%s",
+            stats.discovery_duration,
+            stats.change_detection_duration,
+            stats.archive_creation_duration,
+            stats.context_setup_duration,
+            stats.transfer_duration,
+            self._format_size(stats.source_size),
+            self._format_size(stats.archive_size),
+            stats.mode,
         )
 
         return stats
@@ -1110,21 +1166,53 @@ print(target_dir)
         sharing the same upload, extraction, working-directory, and sys.path
         setup lifecycle.
         """
+        start_time = time.perf_counter()
         if not self.needs_sync():
             return None
 
         if executor.context_id is None:
+            context_setup_start = time.perf_counter()
             executor.create_context()
+            initial_context_setup_duration = time.perf_counter() - context_setup_start
+        else:
+            initial_context_setup_duration = 0.0
 
         stats = self.sync(on_progress=on_progress, executor=executor)
+        if initial_context_setup_duration:
+            stats.context_setup_duration += initial_context_setup_duration
+            stats.remote_calls += 1
         for description, code in self.get_setup_steps(stats.cluster_zip_path):
+            setup_start = time.perf_counter()
             result = (
                 execute_setup(description, code)
                 if execute_setup is not None
                 else executor.execute(code, allow_reconnect=False)
             )
+            setup_duration = time.perf_counter() - setup_start
+            stats.remote_calls += 1
+            if description == "Configuring paths":
+                stats.path_setup_duration += setup_duration
+            else:
+                stats.remote_apply_duration += setup_duration
             if result.status != "ok":
                 raise SetupError(description, result.error)
+        stats.total_duration = time.perf_counter() - start_time
+        stats.sync_duration = stats.total_duration
+        logger.info(
+            "Sync setup complete: remote_apply=%.3fs path_setup=%.3fs "
+            "%d remote calls, %.1fs total",
+            stats.remote_apply_duration,
+            stats.path_setup_duration,
+            stats.remote_calls,
+            stats.total_duration,
+        )
+        logger.debug(
+            "Sync setup diagnostics: remote_apply=%.3fs path_setup=%.3fs "
+            "remote_calls=%d",
+            stats.remote_apply_duration,
+            stats.path_setup_duration,
+            stats.remote_calls,
+        )
         return stats
 
     def get_setup_steps(self, cluster_zip_path: str) -> list[tuple[str, str]]:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import tomllib
 from datetime import timedelta
 from pathlib import Path
@@ -13,10 +14,13 @@ import pytest
 
 from jupyter_databricks_kernel.executor import ExecutionResult
 from jupyter_databricks_kernel.runner import (
+    CLI_LOG_HANDLER_NAME,
+    PACKAGE_LOGGER_NAME,
     cli_run,
     cli_run_db_py,
     cli_run_ipynb,
     cli_run_py,
+    configure_cli_logging,
     detect_run_format,
     prepare_project,
     run_db_py,
@@ -125,6 +129,96 @@ class TestProjectPreparation:
             prepare_project(config, executor)
 
         file_sync.cleanup.assert_called_once_with()
+
+
+class TestCliLogging:
+    """Tests for optional runner logging configuration."""
+
+    def test_configures_logging_from_environment(self) -> None:
+        """Benchmark runs can enable sync diagnostics through an env var."""
+        package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+        old_level = package_logger.level
+        old_propagate = package_logger.propagate
+        old_handlers = list(package_logger.handlers)
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"JUPYTER_DATABRICKS_KERNEL_LOG_LEVEL": "debug"},
+                clear=True,
+            ),
+        ):
+            try:
+                configure_cli_logging()
+
+                assert package_logger.level == logging.DEBUG
+                assert package_logger.propagate is False
+                cli_handlers = [
+                    handler
+                    for handler in package_logger.handlers
+                    if handler.get_name() == CLI_LOG_HANDLER_NAME
+                ]
+                assert len(cli_handlers) == 1
+                assert cli_handlers[0].level == logging.DEBUG
+            finally:
+                package_logger.handlers = old_handlers
+                package_logger.setLevel(old_level)
+                package_logger.propagate = old_propagate
+
+    def test_ignores_invalid_logging_level(self) -> None:
+        """Invalid log levels do not alter process logging."""
+        package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+        old_level = package_logger.level
+        old_propagate = package_logger.propagate
+        old_handlers = list(package_logger.handlers)
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"JUPYTER_DATABRICKS_KERNEL_LOG_LEVEL": "verbose"},
+                clear=True,
+            ),
+        ):
+            try:
+                configure_cli_logging()
+
+                assert package_logger.handlers == old_handlers
+                assert package_logger.level == old_level
+                assert package_logger.propagate is old_propagate
+            finally:
+                package_logger.handlers = old_handlers
+                package_logger.setLevel(old_level)
+                package_logger.propagate = old_propagate
+
+    def test_cli_logging_does_not_enable_unrelated_loggers(self) -> None:
+        """The package env var does not take ownership of root logging."""
+        package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+        unrelated_logger = logging.getLogger("unrelated.package")
+        root_logger = logging.getLogger()
+        old_package_level = package_logger.level
+        old_package_propagate = package_logger.propagate
+        old_package_handlers = list(package_logger.handlers)
+        old_unrelated_level = unrelated_logger.level
+        old_root_level = root_logger.level
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"JUPYTER_DATABRICKS_KERNEL_LOG_LEVEL": "debug"},
+                clear=True,
+            ),
+            patch("logging.basicConfig") as basic_config,
+        ):
+            try:
+                configure_cli_logging()
+
+                basic_config.assert_not_called()
+                assert unrelated_logger.level == old_unrelated_level
+                assert root_logger.level == old_root_level
+            finally:
+                package_logger.handlers = old_package_handlers
+                package_logger.setLevel(old_package_level)
+                package_logger.propagate = old_package_propagate
 
 
 # ---------------------------------------------------------------------------
@@ -436,6 +530,54 @@ class TestCliRun:
         file_sync.cleanup.assert_called_once_with()
         executor.destroy_context.assert_called_once_with()
 
+    def test_cli_leaves_context_creation_inside_preparation_boundary(
+        self, tmp_path: Path
+    ) -> None:
+        """CLI setup does not create a remote context before project preparation."""
+        import sys
+
+        file_path = tmp_path / "script.py"
+        output_dir = tmp_path / "outputs"
+        config = MagicMock()
+        executor = _make_executor()
+        file_sync = MagicMock()
+        events: list[str] = []
+
+        def prepare(config_arg: object, executor_arg: object) -> MagicMock:
+            assert config_arg is config
+            assert executor_arg is executor
+            executor.create_context.assert_not_called()
+            events.append("prepare")
+            executor.create_context()
+            return file_sync
+
+        def dispatch(*args: object, **kwargs: object) -> ExecutionResult:
+            events.append("dispatch")
+            return ExecutionResult(status="ok", output="done")
+
+        with (
+            patch.object(
+                sys,
+                "argv",
+                ["databricks-run", str(file_path), "--output-dir", str(output_dir)],
+            ),
+            patch("jupyter_databricks_kernel.config.Config.load", return_value=config),
+            patch(
+                "jupyter_databricks_kernel.executor.DatabricksExecutor",
+                return_value=executor,
+            ),
+            patch(
+                "jupyter_databricks_kernel.runner.prepare_project", side_effect=prepare
+            ),
+            patch("jupyter_databricks_kernel.runner.run_file", side_effect=dispatch),
+        ):
+            cli_run()
+
+        assert events == ["prepare", "dispatch"]
+        executor.create_context.assert_called_once_with()
+        file_sync.cleanup.assert_called_once_with()
+        executor.destroy_context.assert_called_once_with()
+
     def test_cli_preparation_failure_writes_error_and_destroys_context(
         self, tmp_path: Path
     ) -> None:
@@ -530,7 +672,7 @@ class TestCliRun:
         ):
             cli_run()
 
-        executor.create_context.assert_called_once_with()
+        executor.create_context.assert_not_called()
         executor.execute.assert_called_once_with(
             "print('cli')\n", timeout=timedelta(seconds=600)
         )

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -779,23 +779,99 @@ class TestSyncAndSetup:
     def test_reuses_executor_for_upload_and_setup(self, file_sync: FileSync) -> None:
         """One executor context performs both project upload and setup steps."""
         executor = MagicMock(context_id="context-id")
-        stats = SyncStats(cluster_zip_path="/tmp/project.zip")
-        setup_steps = [("Configuring paths", "sys.path.insert(0, '/tmp/project')")]
+        stats = SyncStats(
+            cluster_zip_path="/tmp/project.zip",
+            remote_calls=2,
+            sync_duration=1.0,
+        )
+        setup_steps = [
+            ("Extracting files", "extract()"),
+            ("Configuring paths", "sys.path.insert(0, '/tmp/project')"),
+        ]
         executor.execute.return_value = MagicMock(status="ok")
 
         with (
             patch.object(file_sync, "needs_sync", return_value=True),
             patch.object(file_sync, "sync", return_value=stats) as sync,
             patch.object(file_sync, "get_setup_steps", return_value=setup_steps),
+            patch(
+                "jupyter_databricks_kernel.sync.time.perf_counter",
+                side_effect=[10.0, 20.0, 20.25, 30.0, 30.5, 40.0],
+            ),
         ):
             result = file_sync.sync_and_setup(executor)
 
         assert result is stats
         sync.assert_called_once_with(on_progress=None, executor=executor)
         executor.create_context.assert_not_called()
-        executor.execute.assert_called_once_with(
+        assert executor.execute.call_count == 2
+        executor.execute.assert_any_call("extract()", allow_reconnect=False)
+        executor.execute.assert_any_call(
             "sys.path.insert(0, '/tmp/project')", allow_reconnect=False
         )
+        assert stats.remote_calls == 4
+        assert stats.remote_apply_duration == 0.25
+        assert stats.path_setup_duration == 0.5
+        assert stats.upload_duration == 0.0
+        assert stats.total_duration == 30.0
+        assert stats.sync_duration == 30.0
+
+    def test_counts_executor_context_creation_in_setup_boundary(
+        self, file_sync: FileSync
+    ) -> None:
+        """End-to-end setup stats include an executor context created up front."""
+        executor = MagicMock(context_id=None)
+        stats = SyncStats(cluster_zip_path="/tmp/project.zip", remote_calls=2)
+
+        with (
+            patch.object(file_sync, "needs_sync", return_value=True),
+            patch.object(file_sync, "sync", return_value=stats),
+            patch.object(file_sync, "get_setup_steps", return_value=[]),
+            patch(
+                "jupyter_databricks_kernel.sync.time.perf_counter",
+                side_effect=[5.0, 5.1, 5.4, 6.0],
+            ),
+        ):
+            result = file_sync.sync_and_setup(executor)
+
+        assert result is stats
+        executor.create_context.assert_called_once_with()
+        assert stats.context_setup_duration == pytest.approx(0.3)
+        assert stats.remote_calls == 3
+        assert stats.upload_duration == 0.0
+        assert stats.total_duration == 1.0
+        assert stats.sync_duration == 1.0
+
+    def test_total_duration_includes_needs_sync_preflight(
+        self, file_sync: FileSync
+    ) -> None:
+        """End-to-end setup timing starts before sync preflight checks."""
+        executor = MagicMock(context_id="context-id")
+        stats = SyncStats(cluster_zip_path="/tmp/project.zip", remote_calls=2)
+
+        def needs_sync_with_preflight() -> bool:
+            preflight_start = time.perf_counter()
+            preflight_end = time.perf_counter()
+            assert preflight_end - preflight_start == 1.0
+            return True
+
+        with (
+            patch.object(
+                file_sync, "needs_sync", side_effect=needs_sync_with_preflight
+            ),
+            patch.object(file_sync, "sync", return_value=stats),
+            patch.object(file_sync, "get_setup_steps", return_value=[]),
+            patch(
+                "jupyter_databricks_kernel.sync.time.perf_counter",
+                side_effect=[1.0, 2.0, 3.0, 6.0],
+            ),
+        ):
+            result = file_sync.sync_and_setup(executor)
+
+        assert result is stats
+        executor.create_context.assert_not_called()
+        assert stats.total_duration == 5.0
+        assert stats.sync_duration == 5.0
 
     def test_skips_upload_and_setup_when_no_sync_is_needed(
         self, file_sync: FileSync
@@ -875,27 +951,86 @@ class TestSyncStats:
         stats = SyncStats()
         assert stats.changed_files == 0
         assert stats.changed_size == 0
+        assert stats.deleted_files == 0
         assert stats.skipped_files == 0
         assert stats.total_files == 0
+        assert stats.upload_duration == 0.0
+        assert stats.total_duration == 0.0
         assert stats.sync_duration == 0.0
         assert stats.cluster_zip_path == ""
+        assert stats.source_size == 0
+        assert stats.archive_size == 0
+        assert stats.chunk_count == 0
+        assert stats.remote_calls == 0
+        assert stats.mode == "full"
+        assert stats.discovery_duration == 0.0
+        assert stats.change_detection_duration == 0.0
+        assert stats.archive_creation_duration == 0.0
+        assert stats.context_setup_duration == 0.0
+        assert stats.transfer_duration == 0.0
+        assert stats.remote_apply_duration == 0.0
+        assert stats.path_setup_duration == 0.0
 
     def test_with_values(self) -> None:
         """Test with custom values."""
         stats = SyncStats(
             changed_files=3,
             changed_size=1024,
+            deleted_files=2,
             skipped_files=10,
             total_files=13,
+            upload_duration=1.25,
+            total_duration=2.5,
             sync_duration=1.5,
             cluster_zip_path="/tmp/test/project.zip",
+            source_size=4096,
+            archive_size=2048,
+            chunk_count=1,
+            remote_calls=5,
+            mode="full",
+            discovery_duration=0.1,
+            change_detection_duration=0.2,
+            archive_creation_duration=0.3,
+            context_setup_duration=0.4,
+            transfer_duration=0.5,
+            remote_apply_duration=0.6,
+            path_setup_duration=0.7,
         )
+        assert stats.changed_files == 3
+        assert stats.changed_size == 1024
+        assert stats.deleted_files == 2
+        assert stats.skipped_files == 10
+        assert stats.total_files == 13
+        assert stats.upload_duration == 1.25
+        assert stats.total_duration == 2.5
+        assert stats.sync_duration == 1.5
+        assert stats.cluster_zip_path == "/tmp/test/project.zip"
+        assert stats.source_size == 4096
+        assert stats.archive_size == 2048
+        assert stats.chunk_count == 1
+        assert stats.remote_calls == 5
+        assert stats.mode == "full"
+        assert stats.discovery_duration == 0.1
+        assert stats.change_detection_duration == 0.2
+        assert stats.archive_creation_duration == 0.3
+        assert stats.context_setup_duration == 0.4
+        assert stats.transfer_duration == 0.5
+        assert stats.remote_apply_duration == 0.6
+        assert stats.path_setup_duration == 0.7
+
+    def test_preserves_positional_constructor_contract(self) -> None:
+        """The original six positional fields remain in their existing order."""
+        stats = SyncStats(3, 1024, 10, 13, 1.5, "/tmp/test/project.zip")
+
         assert stats.changed_files == 3
         assert stats.changed_size == 1024
         assert stats.skipped_files == 10
         assert stats.total_files == 13
         assert stats.sync_duration == 1.5
         assert stats.cluster_zip_path == "/tmp/test/project.zip"
+        assert stats.deleted_files == 0
+        assert stats.upload_duration == 0.0
+        assert stats.total_duration == 0.0
 
 
 class TestDefaultExcludePatterns:
@@ -1599,6 +1734,59 @@ class TestCommandAPITransfer:
             for command in chunk_commands
         ]
         assert b"".join(base64.b64decode(chunk) for chunk in encoded_chunks) == payload
+
+    def test_sync_records_phase_diagnostics(
+        self, mock_file_sync: FileSync, tmp_path: Path
+    ) -> None:
+        """Sync reports phase timings and transfer counters for benchmarks."""
+        test_file = tmp_path / "test.py"
+        test_file.write_text("print('test')\n")
+        payload = b"z" * (COMMAND_API_BINARY_CHUNK_SIZE + 23)
+        mock_file_sync.config.base_path = tmp_path
+
+        fake_cache = MagicMock()
+        fake_cache.get_changed_files.return_value = (
+            [test_file],
+            SyncStats(changed_files=1, changed_size=test_file.stat().st_size),
+            {"test.py": "hash"},
+        )
+        fake_cache.get_deleted_files.return_value = ["deleted.py"]
+
+        mock_file_sync._get_all_files = Mock(return_value=[test_file])
+        mock_file_sync._get_file_cache = Mock(return_value=fake_cache)
+        mock_file_sync._create_zip = Mock(return_value=payload)
+
+        result = MagicMock()
+        from databricks.sdk.service import compute
+
+        result.status = compute.CommandStatus.FINISHED
+        result.results = MagicMock()
+        result.results.cause = None
+        result.results.data = "/tmp/jupyter_databricks_kernel_test-session"
+        execute_response = mock_file_sync.client.command_execution.execute.return_value
+        execute_response.result.return_value = result
+
+        stats = mock_file_sync.sync()
+
+        assert stats.total_files == 1
+        assert stats.changed_files == 1
+        assert stats.deleted_files == 1
+        assert stats.source_size == test_file.stat().st_size
+        assert stats.archive_size == len(payload)
+        assert stats.chunk_count == count_command_api_base64_chunks(len(payload))
+        assert stats.remote_calls == stats.chunk_count + 2
+        assert stats.mode == "full"
+        assert stats.cluster_zip_path.endswith("/project.zip")
+        assert stats.upload_duration >= 0
+        assert stats.total_duration == stats.upload_duration
+        assert stats.sync_duration >= 0
+        assert stats.sync_duration == stats.total_duration
+        assert stats.discovery_duration >= 0
+        assert stats.change_detection_duration >= 0
+        assert stats.archive_creation_duration >= 0
+        assert stats.context_setup_duration >= 0
+        assert stats.transfer_duration >= 0
+        fake_cache.remove.assert_called_once_with("deleted.py")
 
     def test_executor_context_sharing(
         self, mock_file_sync: FileSync, tmp_path: Path


### PR DESCRIPTION
## Summary
- Add phase-level sync diagnostics for discovery, change detection, archive creation, context setup, transfer, remote apply, and path setup.
- Add package-scoped CLI logging for benchmark diagnostics without changing default runner output.
- Add a reproducible manual sync benchmark with deterministic fixture setup and path-free reporting.

## Compatibility and privacy
- Preserves the original six-field SyncStats positional-constructor order.
- Keeps sync_duration as a backward-compatible alias for the returned operation total.
- Separates upload timing from end-to-end preparation timing.
- Avoids printing cluster_zip_path or driver-local paths in benchmark rows.

## Validation
- Focused sync and runner tests: 147 passed.
- Full suite with the known command-scoped GCC runtime workaround: 310 passed, 5 skipped.
- Ruff lint and format checks passed.
- Mypy passed with no issues in 9 source files.
- rumdl passed for the benchmark documentation.
- git diff --check passed.
- Timing, positional-constructor, package-logger, path-redaction, and fixture-count probes passed.

Refs #369.
