### PR TITLE
feat: deprecate Python 3.11

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,11 @@ jupyter-databricks-kernel!
 - [uv](https://docs.astral.sh/uv/) for dependency management
 - [Nix](https://nixos.org/) (recommended, for pre-commit hooks)
 
+Python 3.11 remains supported until v2.0, planned for 2027, but is deprecated.
+Local development environments should migrate to Python 3.12 or later before
+moving to v2.0. Managed-runtime users should move from Databricks Runtime 15.4
+LTS to Databricks Runtime 16.4 LTS or 17.3 LTS.
+
 ### 1.2. With Nix (recommended)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ A Jupyter kernel for complete remote execution on Databricks clusters.
   Token, OAuth M2M with Service Principal, etc.)
 - Classic all-purpose cluster
 
+### 2.1. Python 3.11 Deprecation
+
+Python 3.11 remains supported for existing environments, but it is deprecated
+and will be removed in v2.0 as part of the planned 2027 breaking-release work.
+Local environments should migrate to Python 3.12 or later before moving to
+v2.0. Managed-runtime users should move from Databricks Runtime 15.4 LTS to
+Databricks Runtime 16.4 LTS or 17.3 LTS.
+
 ## 3. Quick Start
 
 1. Install the kernel:

--- a/src/jupyter_databricks_kernel/__init__.py
+++ b/src/jupyter_databricks_kernel/__init__.py
@@ -1,5 +1,26 @@
 """Jupyter kernel for Databricks remote execution."""
 
+import sys
+import warnings
+from collections.abc import Sequence
+
 from ._version import __version__
+
+
+def _warn_if_python_311(version_info: Sequence[int] | None = None) -> None:
+    """Warn when the current interpreter is Python 3.11."""
+    version = sys.version_info if version_info is None else version_info
+    if tuple(version[:2]) != (3, 11):
+        return
+
+    warnings.warn(
+        "Python 3.11 support is deprecated and will be removed in v2.0; "
+        "upgrade to Python 3.12 or later.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+
+_warn_if_python_311()
 
 __all__ = ["__version__"]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,66 @@
+"""Tests for package startup behavior."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import warnings
+
+import pytest
+
+import jupyter_databricks_kernel
+from jupyter_databricks_kernel import _warn_if_python_311
+
+
+def _reload_package_with_version(
+    monkeypatch: pytest.MonkeyPatch, version_info: tuple[int, int, int]
+) -> list[warnings.WarningMessage]:
+    """Reload the package with a simulated interpreter version."""
+    monkeypatch.setattr(sys, "version_info", version_info)
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        importlib.reload(jupyter_databricks_kernel)
+    return caught_warnings
+
+
+def test_warn_if_python_311_emits_deprecation_warning() -> None:
+    """Python 3.11 receives a migration warning."""
+    with pytest.warns(
+        DeprecationWarning,
+        match="Python 3.11 support is deprecated.*Python 3.12 or later",
+    ):
+        _warn_if_python_311((3, 11, 0))
+
+
+def test_warn_if_python_311_ignores_newer_versions() -> None:
+    """Python 3.12 and later do not receive the migration warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_if_python_311((3, 12, 0))
+
+
+def test_package_startup_warns_on_python_311(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Package startup emits exactly one migration warning on Python 3.11."""
+    caught_warnings = _reload_package_with_version(monkeypatch, (3, 11, 0))
+
+    warning_details = [
+        (warning.category, str(warning.message)) for warning in caught_warnings
+    ]
+    assert warning_details == [
+        (
+            DeprecationWarning,
+            "Python 3.11 support is deprecated and will be removed in v2.0; "
+            "upgrade to Python 3.12 or later.",
+        )
+    ]
+
+
+def test_package_startup_does_not_warn_on_python_312_or_later(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Package startup does not emit the migration warning on Python 3.12+."""
+    caught_warnings = _reload_package_with_version(monkeypatch, (3, 12, 0))
+
+    assert caught_warnings == []


### PR DESCRIPTION
## Summary

- emit a package-startup deprecation warning on Python 3.11 while preserving support until v2.0 planned in 2027
- document migration to local Python 3.12+ and from Databricks Runtime 15.4 LTS to 16.4 LTS or 17.3 LTS
- add deterministic import/reload coverage for Python 3.11 and 3.12+

## Validation

- focused tests: 4 passed
- full suite: 306 passed, 5 skipped
- Ruff, formatting, mypy, Rumdl, diff checks, and commit hooks passed

Closes #15